### PR TITLE
Adding Android build support possibility, plus a README to describe support

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,0 +1,5 @@
+# (C) IoTone, Inc. 2015
+#
+LOCAL_PATH := $(call my-dir)
+subdirs := $(call all-subdir-makefiles)
+include $(subdirs)

--- a/README-Android.md
+++ b/README-Android.md
@@ -1,0 +1,21 @@
+Overivew
+========
+
+Android build support is under development.  Because the methodologies for Android NDK-based development
+are in flux, there are currently at least 4-5 supported ways to build projects:
+
+* Android NDK
+* Android SDK *(Command Line)
+* Eclipse Android Plugin Based Builds
+* Android Studio Based Builds
+* Gradle Android Plugin (Command Line)
+* Custom Makefiles
+* Maven Android Plugin
+
+It is not the goal of this Android integration to easily support all possible ways to build.  Instead, the project
+shall focus on adding the most commonly understood approach to building JNI code with the Android NDK.
+
+Status
+======
+
+The project currently will not build with the Android NDK.  Compilation will fail.

--- a/src/Android.mk
+++ b/src/Android.mk
@@ -1,0 +1,40 @@
+# (C) IoTone, Inc. 2015
+#
+
+# set this if we want release type, ?? is this required
+# TARGET_BUILD_TYPE:= release
+
+LOCAL_PATH:= $(call my-dir)
+
+include $(CLEAR_VARS)
+
+LOCAL_C_INCLUDES += $(LOCAL_PATH)
+
+
+LOCAL_CFLAGS += -W -Wall
+LOCAL_CFLAGS += -fPIC -DPIC
+# LOCAL_CFLAGS += -fexceptions -DXLOCALE_NOT_USED -DSOCKLEN_T=socklen_t -DBSD=0 -DNO_SSTREAM
+
+# LOCAL_CFLAGS += -v
+# LOCAL_LDLIBS := -llog -lz
+
+ifeq ($(TARGET_BUILD_TYPE),release)
+    LOCAL_CFLAGS += -O2
+endif
+
+LOCAL_MODULE:= libccn-lite
+
+# LOCAL_STATIC_LIBRARIES := libBasicUsageEnvironment libgroupsock
+LOCAL_SHARED_LIBRARIES :=
+
+#
+# Brilliant little WC trick: http://stackoverflow.com/a/12827889/796514
+#
+#
+# This would select all sources in subdirs
+#
+# This would select all sources in subdirs
+LOCAL_SRC_FILES := \
+    $(subst $(LOCAL_PATH)/,,$(wildcard $(LOCAL_PATH)/*.c) $(wildcard $(LOCAL_PATH)/*/*.c)))
+
+include $(BUILD_SHARED_LIBRARY)


### PR DESCRIPTION
Adding basic Android build support.  Android.mk files do not affect existing build.  Added a README to describe how the integration is supported.  Requires additional support by a project in order to integrate it into an Android project.  However, this is a first step at adding proper Android support.  Will not currently build.  I will file a bug related to the ndk-build issues.