### PR TITLE
updating glibc feature test macros

### DIFF
--- a/src/ccn-lite-minimalrelay.c
+++ b/src/ccn-lite-minimalrelay.c
@@ -44,7 +44,7 @@
 #include <arpa/inet.h>
 #include <netinet/in.h>
 
-#if !(defined(_BSD_SOURCE) && defined(SVID_SOURCE))
+#ifndef _DEFAULT_SOURCE
 int inet_aton(const char *cp, struct in_addr *inp);
 #endif
 

--- a/src/ccnl-os-includes.h
+++ b/src/ccnl-os-includes.h
@@ -44,7 +44,7 @@
 # include <sys/un.h>
 # include <sys/utsname.h>
 
-#if !(defined(_BSD_SOURCE) || defined(SVID_SOURCE))
+#ifndef _DEFAULT_SOURCE
 #  define __USE_MISC
 #endif
 
@@ -52,7 +52,7 @@
 #include <netinet/in.h>
 #include <net/if.h> // IFNAMSIZE, if_nametoindex
 
-#if !(defined(_BSD_SOURCE) || defined(SVID_SOURCE))
+#ifdef _DEFAULT_SOURCE
   int inet_aton(const char *cp, struct in_addr *inp);
 #endif
 

--- a/src/util/ccnl-common.c
+++ b/src/util/ccnl-common.c
@@ -28,6 +28,7 @@
 
 #define USE_LOGGING
 #define CCNL_UNIX
+#define _DEFAULT_SOURCE
 #define _BSD_SOURCE
 #define _SVID_SOURCE
 


### PR DESCRIPTION
In current glibc versions _BSD_SOURCE and _SVID_SOURCE are marked and create compiler warnings, _DEFAULT_SOURCE can be used instead.

Current master won't compile with gcc 5.2.0 and glibc 2.22, because of
```
In file included from /usr/include/fcntl.h:25:0,
                 from ccnl-common.c:41,
                 from ccn-lite-ccnb2xml.c:31:
/usr/include/features.h:148:3: error: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Werror=cpp]
 # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
   ^
```