### PR TITLE
fix signedness

### DIFF
--- a/src/ccn-lite-relay.c
+++ b/src/ccn-lite-relay.c
@@ -608,7 +608,8 @@ ccnl_populate_cache(struct ccnl_relay_s *ccnl, char *path)
         unsigned char *data;
         (void) data; // silence compiler warning (if any USE_SUITE_* is not set)
 #if defined(USE_SUITE_IOTTLV) || defined(USE_SUITE_NDNTLV)
-        unsigned int typ, len;
+        unsigned int typ;
+        int len;
 #endif
         struct ccnl_pkt_s *pk;
 

--- a/src/ccn-lite-simu.c
+++ b/src/ccn-lite-simu.c
@@ -290,7 +290,7 @@ ccnl_ll_TX(struct ccnl_relay_s *relay, struct ccnl_if_s *ifc,
 
     for (cnt = 0, p = etherqueue; p; p = p->next, cnt++);
 
-    DEBUGMSG(TRACE, "eth(simu)_ll_TX to %s len=%d (qlen=%d) [0x%02x 0x%02x]\n",
+    DEBUGMSG(TRACE, "eth(simu)_ll_TX to %s len=%zd (qlen=%d) [0x%02x 0x%02x]\n",
              ccnl_addr2ascii(dst), buf->datalen, cnt,
              buf->data[0], buf->data[1]);
     DEBUGMSG(TRACE, "  src=%s\n", ccnl_addr2ascii(&ifc->addr));

--- a/src/ccnl-core-fwd.c
+++ b/src/ccnl-core-fwd.c
@@ -97,7 +97,7 @@ ccnl_fwd_handleFragment(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     unsigned char *data = (*pkt)->content;
     int datalen = (*pkt)->contlen;
 
-    DEBUGMSG_CFWD(INFO, "  incoming fragment (%d bytes) from=%s\n",
+    DEBUGMSG_CFWD(INFO, "  incoming fragment (%zd bytes) from=%s\n",
                   (*pkt)->buf->datalen,
                   ccnl_addr2ascii(from ? &from->peer : NULL));
 
@@ -574,8 +574,8 @@ int
 ccnl_iottlv_forwarder(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
                       unsigned char **data, int *datalen)
 {
-    int rc = -1, enc;
-    unsigned int typ, len;
+    int rc = -1, enc, len;
+    unsigned int typ;
     unsigned char *start = *data;
     struct ccnl_pkt_s *pkt;
 
@@ -600,7 +600,7 @@ ccnl_iottlv_forwarder(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
         DEBUGMSG_CFWD(INFO, "  parsing error or no prefix\n");
         goto Done;
     }
-    DEBUGMSG_CFWD(DEBUG, "  parsed packet has %d bytes\n", pkt->buf->datalen);
+    DEBUGMSG_CFWD(DEBUG, "  parsed packet has %zd bytes\n", pkt->buf->datalen);
     pkt->type = typ;
 
     switch (typ) {
@@ -641,8 +641,8 @@ int
 ccnl_ndntlv_forwarder(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
                       unsigned char **data, int *datalen)
 {
-    int rc = -1;
-    unsigned int typ, len;
+    int rc = -1, len;
+    unsigned int typ;
     unsigned char *start = *data;
     struct ccnl_pkt_s *pkt;
 

--- a/src/ccnl-core-util.c
+++ b/src/ccnl-core-util.c
@@ -572,7 +572,7 @@ ccnl_URItoPrefix(char* uri, int suite, char *nfnexpr, unsigned int *chunknum)
 #endif
 
     if(chunknum) {
-        p->chunknum = (unsigned int*) ccnl_malloc(sizeof(int));
+        p->chunknum = (int*) ccnl_malloc(sizeof(int));
         *p->chunknum = *chunknum;
     }
 
@@ -611,7 +611,7 @@ ccnl_prefix_dup(struct ccnl_prefix_s *prefix)
     }
 
     if (prefix->chunknum) {
-        p->chunknum = (unsigned int*) ccnl_malloc(sizeof(int));
+        p->chunknum = (int*) ccnl_malloc(sizeof(int));
         *p->chunknum = *prefix->chunknum;
     }
 
@@ -682,7 +682,7 @@ ccnl_prefix_addChunkNum(struct ccnl_prefix_s *prefix, unsigned int chunknum)
                 return -1;
             if (prefix->chunknum)
                 ccnl_free(prefix->chunknum);
-            prefix->chunknum = (unsigned int*) ccnl_malloc(sizeof(int));
+            prefix->chunknum = (int*) ccnl_malloc(sizeof(int));
             *prefix->chunknum = chunknum;
         }
         break;
@@ -701,7 +701,7 @@ ccnl_prefix_addChunkNum(struct ccnl_prefix_s *prefix, unsigned int chunknum)
                 return -1;
             if (prefix->chunknum)
                 ccnl_free(prefix->chunknum);
-            prefix->chunknum = (unsigned int*) ccnl_malloc(sizeof(int));
+            prefix->chunknum = (int*) ccnl_malloc(sizeof(int));
             *prefix->chunknum = chunknum;
         }
         break;
@@ -720,7 +720,7 @@ ccnl_prefix_addChunkNum(struct ccnl_prefix_s *prefix, unsigned int chunknum)
                 return -1;
             if (prefix->chunknum)
                 ccnl_free(prefix->chunknum);
-            prefix->chunknum = (unsigned int*) ccnl_malloc(sizeof(int));
+            prefix->chunknum = (int*) ccnl_malloc(sizeof(int));
             *prefix->chunknum = chunknum;
         }
         break;
@@ -913,6 +913,8 @@ char*
 ccnl_prefix_to_path_detailed(struct ccnl_prefix_s *pr, int ccntlv_skip,
                              int escape_components, int call_slash)
 {
+    (void) ccntlv_skip;
+    (void) call_slash;
     int len = 0, i, j;
     /*static char *prefix_buf1;
     static char *prefix_buf2;

--- a/src/ccnl-core.c
+++ b/src/ccnl-core.c
@@ -258,7 +258,7 @@ ccnl_interface_enqueue(void (tx_done)(void*, int, int), struct ccnl_face_s *f,
 {
     struct ccnl_txrequest_s *r;
 
-    DEBUGMSG_CORE(TRACE, "enqueue interface=%p buf=%p len=%d (qlen=%d)\n",
+    DEBUGMSG_CORE(TRACE, "enqueue interface=%p buf=%p len=%zd (qlen=%d)\n",
                   (void*)ifc, (void*)buf,
                   buf ? buf->datalen : -1, ifc ? ifc->qlen : -1);
 
@@ -347,7 +347,7 @@ ccnl_face_enqueue(struct ccnl_relay_s *ccnl, struct ccnl_face_s *to,
                  struct ccnl_buf_s *buf)
 {
     struct ccnl_buf_s *msg;
-    DEBUGMSG_CORE(TRACE, "enqueue face=%p (id=%d.%d) buf=%p len=%d\n",
+    DEBUGMSG_CORE(TRACE, "enqueue face=%p (id=%d.%d) buf=%p len=%zd\n",
              (void*) to, ccnl->id, to->faceid, (void*) buf, buf ? buf->datalen : -1);
 
     for (msg = to->outq; msg; msg = msg->next) // already in the queue?
@@ -576,6 +576,7 @@ ccnl_interest_isSame(struct ccnl_interest_s *i, struct ccnl_pkt_s *pkt)
 struct ccnl_content_s*
 ccnl_content_new(struct ccnl_relay_s *ccnl, struct ccnl_pkt_s **pkt)
 {
+    (void) ccnl;
     struct ccnl_content_s *c;
 
     DEBUGMSG_CORE(TRACE, "ccnl_content_new %p <%s [%d]>\n",
@@ -757,6 +758,7 @@ ccnl_content_serve_pending(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
 void
 ccnl_do_ageing(void *ptr, void *dummy)
 {
+    (void) dummy;
     struct ccnl_relay_s *relay = (struct ccnl_relay_s*) ptr;
     struct ccnl_content_s *c = relay->contents;
     struct ccnl_interest_s *i = relay->pit;

--- a/src/ccnl-core.h
+++ b/src/ccnl-core.h
@@ -131,7 +131,7 @@ struct ccnl_relay_s {
 
 struct ccnl_buf_s {
     struct ccnl_buf_s *next;
-    unsigned int datalen;
+    ssize_t datalen;
     unsigned char data[1];
 };
 
@@ -141,9 +141,9 @@ struct ccnl_prefix_s {
     int compcnt;
     char suite;
     unsigned char *nameptr; // binary name (for fast comparison)
-    unsigned int   namelen; // valid length of name memory
+    ssize_t namelen; // valid length of name memory
     unsigned char *bytes;   // memory for name component copies
-    unsigned int *chunknum; // -1 to disable
+    int *chunknum; // -1 to disable
 #ifdef USE_NFN
     unsigned int nfnflags;
 # define CCNL_PREFIX_NFN   0x01

--- a/src/ccnl-ext-debug.c
+++ b/src/ccnl-ext-debug.c
@@ -144,7 +144,7 @@ ccnl_dump(int lev, int typ, void *p)
     case CCNL_BUF:
         while (buf) {
             INDENT(lev);
-            CONSOLE("%p BUF len=%d next=%p\n", (void *) buf, buf->datalen,
+            CONSOLE("%p BUF len=%zd next=%p\n", (void *) buf, buf->datalen,
                 (void *) buf->next);
             buf = buf->next;
         }

--- a/src/ccnl-ext-echo.c
+++ b/src/ccnl-ext-echo.c
@@ -46,7 +46,7 @@ ccnl_echo_request(struct ccnl_relay_s *relay, struct ccnl_face_s *inface,
         pfx->comp[pfx->compcnt-1][1] == CCNX_TLV_N_Chunk) {
         struct ccnl_prefix_s *pfx2 = ccnl_prefix_dup(pfx);
         pfx2->compcnt--;
-        pfx2->chunknum = (unsigned int*) ccnl_malloc(sizeof(unsigned int));
+        pfx2->chunknum = (int*) ccnl_malloc(sizeof(unsigned int));
         *(pfx2->chunknum) = 0;
         pfx = pfx2;
     }

--- a/src/ccnl-ext-frag.c
+++ b/src/ccnl-ext-frag.c
@@ -94,7 +94,7 @@ void
 ccnl_frag_reset(struct ccnl_frag_s *e, struct ccnl_buf_s *buf,
                   int ifndx, sockunion *dst)
 {
-    DEBUGMSG_EFRA(VERBOSE, "ccnl_frag_reset if=%d (%d bytes) dst=%s\n", ifndx,
+    DEBUGMSG_EFRA(VERBOSE, "ccnl_frag_reset if=%d (%zd bytes) dst=%s\n", ifndx,
              buf ? buf->datalen : -1, ccnl_addr2ascii(dst));
     if (!e)
         return;
@@ -378,7 +378,7 @@ ccnl_frag_getnextBE2015(struct ccnl_frag_s *fr, int *ifndx, sockunion *su)
     struct ccnl_buf_s *buf = 0;
     unsigned int datalen = 0;
 
-    DEBUGMSG_EFRA(VERBOSE, "ccnl_frag_getnextBE2015: remaining=%d\n",
+    DEBUGMSG_EFRA(VERBOSE, "ccnl_frag_getnextBE2015: remaining=%zd\n",
                   fr->bigpkt->datalen - fr->sendoffs);
 
     switch(fr->outsuite) {
@@ -415,7 +415,7 @@ ccnl_frag_getnextBE2015(struct ccnl_frag_s *fr, int *ifndx, sockunion *su)
         if (su)
             memcpy(su, &fr->dest, sizeof(*su));
 
-        DEBUGMSG_EFRA(VERBOSE, "  produced %d bytes fragment, seqnr=%d-1\n",
+        DEBUGMSG_EFRA(VERBOSE, "  produced %zd bytes fragment, seqnr=%d-1\n",
                  buf->datalen, fr->sendseq);
     } else
         DEBUGMSG_EFRA(VERBOSE, "  produced NO fragment, seqnr remains at =%d-1\n",
@@ -429,7 +429,7 @@ ccnl_frag_getnext(struct ccnl_frag_s *fr, int *ifndx, sockunion *su)
 {
     if (!fr->bigpkt) return NULL;
 
-    DEBUGMSG_EFRA(VERBOSE, "fragmenting %d bytes (@ %d)\n",
+    DEBUGMSG_EFRA(VERBOSE, "fragmenting %zd bytes (@ %d)\n",
                                 fr->bigpkt->datalen, fr->sendoffs);
 
     switch (fr->protocol) {
@@ -880,7 +880,7 @@ ccnl_frag_RX_BeginEnd2015(RX_datagram callback, struct ccnl_relay_s *relay,
     if (buf) {
         unsigned char *frag = buf->data;
         int fraglen = buf->datalen;
-        DEBUGMSG_EFRA(DEBUG, "  >> reassembled fragment is %d bytes\n",
+        DEBUGMSG_EFRA(DEBUG, "  >> reassembled fragment is %zd bytes\n",
                       buf->datalen);
         // FIXME: loop over multiple packets in this reassembled frame?
         callback(relay, from, &frag, &fraglen);

--- a/src/ccnl-ext-nfn.c.orig
+++ b/src/ccnl-ext-nfn.c.orig
@@ -1,0 +1,345 @@
+/*
+ * @f ccnl-ext-nfn.c
+ * @b CCN-lite, NFN related routines
+ *
+ * Copyright (C) 2014, Christopher Scherb, University of Basel
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * File history:
+ * 2014-02-06 <christopher.scherb@unibas.ch>created
+ */
+
+#ifdef USE_NFN
+
+#include "ccnl-core.h"
+#include "ccnl-ext-nfn.h"
+
+struct builtin_s *op_extensions;
+struct builtin_s bifs[];
+
+#include "ccnl-ext-nfncommon.c"
+#include "ccnl-ext-nfnparse.c"
+#include "ccnl-ext-nfnkrivine.c"
+#include "ccnl-ext-nfnops.c"
+
+void
+ZAM_init(void)
+{
+}
+
+struct configuration_s*
+ccnl_nfn_findConfig(struct configuration_s *config_list, int configid)
+{
+    struct configuration_s *config;
+
+    for (config = config_list; config; config = config->next)
+        if(config->configid == configid)
+            return config;
+
+    return NULL;
+}
+
+static int
+ccnl_nfn_count_required_thunks(char *str)
+{
+    int num = 0;
+    char *tok;
+    tok = str;
+    while((tok = strstr(tok, "call")) != NULL ){
+        tok += 4;
+        ++num;
+    }
+    DEBUGMSG(DEBUG, "Number of required Thunks is: %d\n", num);
+    return num;
+}
+
+void
+ccnl_nfn_continue_computation(struct ccnl_relay_s *ccnl, int configid, int continue_from_remove){
+    DEBUGMSG(TRACE, "ccnl_nfn_continue_computation()\n");
+    struct configuration_s *config = ccnl_nfn_findConfig(ccnl->km->configuration_list, -configid);
+
+    if(!config){
+        DEBUGMSG(DEBUG, "nfn_continue_computation: %d not found\n", configid);
+        return;
+    }
+
+    //update original interest prefix to stay longer...reenable if propagate=0 do not protect interests
+    struct ccnl_interest_s *original_interest;
+    for(original_interest = ccnl->pit; original_interest; original_interest = original_interest->next){
+        if(!ccnl_prefix_cmp(config->prefix, 0, original_interest->pkt->pfx, CMP_EXACT)){
+            original_interest->last_used = CCNL_NOW();
+            original_interest->retries = 0;
+            original_interest->from->last_used = CCNL_NOW();
+            break;
+        }
+    }
+    if(config->thunk && CCNL_NOW() > config->endtime){
+        DEBUGMSG(INFO, "NFN: Exit computation: timeout when resolving thunk\n");
+        DBL_LINKED_LIST_REMOVE(ccnl->km->configuration_list, config);
+        //Reply error!
+        //config->thunk = 0;
+        return;
+    }
+    ccnl_nfn(ccnl, NULL, NULL, config, NULL, 0, 0);
+    TRACEOUT();
+}
+
+void
+ccnl_nfn_nack_local_computation(struct ccnl_relay_s *ccnl,
+                                struct ccnl_buf_s *orig,
+                                struct ccnl_prefix_s *prefix,
+                                struct ccnl_face_s *from,
+                                int suite)
+{
+    DEBUGMSG(TRACE, "ccnl_nfn_nack_local_computation\n");
+
+    ccnl_nfn(ccnl, prefix, from, NULL, NULL, suite, 1);
+    TRACEOUT();
+}
+
+int
+ccnl_nfn_thunk_already_computing(struct ccnl_relay_s *ccnl,
+                                 struct ccnl_prefix_s *prefix)
+{
+    int i = 0;
+    struct ccnl_prefix_s *copy;
+
+    DEBUGMSG(TRACE, "ccnl_nfn_thunk_already_computing()\n");
+
+    copy = ccnl_prefix_dup(prefix);
+    // ccnl_nfn_remove_thunk_from_prefix(copy);
+    ccnl_nfnprefix_set(copy, CCNL_PREFIX_NFN | CCNL_PREFIX_THUNK);
+
+    for (i = 0; i < -ccnl->km->configid; ++i) {
+        struct configuration_s *config;
+
+        config = ccnl_nfn_findConfig(ccnl->km->configuration_list, -i);
+        if (!config)
+            continue;
+        if (!ccnl_prefix_cmp(config->prefix, NULL, copy, CMP_EXACT)) {
+            free_prefix(copy);
+            return 1;
+        }
+    }
+    free_prefix(copy);
+
+    return 0;
+}
+
+int
+ccnl_nfn(struct ccnl_relay_s *ccnl, // struct ccnl_buf_s *orig,
+         struct ccnl_prefix_s *prefix, struct ccnl_face_s *from,
+         struct configuration_s *config, struct ccnl_interest_s *interest,
+         int suite, int start_locally)
+{
+    int num_of_required_thunks = 0;
+    int thunk_request = 0;
+    struct ccnl_buf_s *res = NULL;
+    char str[CCNL_MAX_PACKET_SIZE];
+    unsigned int remLen = CCNL_ARRAY_SIZE(str), totalLen = 0, offset = 0;
+    char *tmpStr = str;
+    int i;
+    char prefixBuf[CCNL_PREFIX_BUFSIZE];
+
+    DEBUGSTMT(DEBUG, ccnl_prefix2path(prefixBuf, CCNL_ARRAY_SIZE(prefixBuf), prefix));
+    DEBUGMSG(TRACE, "ccnl_nfn(%p, %s, %p, config=%p)\n",
+             (void *) ccnl, prefixBuf, (void *) from, (void *) config);
+
+    //    prefix = ccnl_prefix_dup(prefix);
+    DEBUGMSG(DEBUG, "Namecomps: %s \n", prefixBuf);
+
+    if (config){
+        suite = config->suite;
+        thunk_request = config->fox_state->thunk_request;
+        goto restart; //do not do parsing thunks again
+    }
+
+    from->flags = CCNL_FACE_FLAGS_STATIC;
+
+    if (ccnl_nfn_thunk_already_computing(ccnl, prefix)) {
+        DEBUGMSG(DEBUG, "Computation for this interest is already running\n");
+        return -1;
+    }
+    if (ccnl_nfnprefix_isTHUNK(prefix))
+        thunk_request = 1;
+
+
+    // Checks first if the interest has a routing hint and then searches for it locally.
+    // If it exisits, the computation is started locally,  otherwise it is directly forwarded without entering the AM.
+    // Without this mechanism, there will be situations where several nodes "overtake" a computation
+    // applying the same strategy and, potentially, all executing it locally (after trying all arguments).
+    // TODO: this is not an elegant solution and should be improved on, because the clients cannot send a
+    // computation with a routing hint on which the network applies a strategy if the routable name
+    // does not exist (because each node will just forward it without ever taking it into an abstract machine).
+    // encoding the routing hint more explicitely as well as additonal information (e.g. already tried names)
+    // could solve the problem. More generally speaking, additional state describing the exact situation will be required.
+
+    if (interest && interest->pkt->pfx->compcnt > 1) { // forward interests with outsourced components
+        struct ccnl_prefix_s *copy = ccnl_prefix_dup(prefix);
+        copy->compcnt -= (1 + thunk_request);
+        DEBUGMSG(DEBUG, "   checking local available of %s\n",
+                 ccnl_prefix2path(prefixBuf, CCNL_ARRAY_SIZE(prefixBuf), copy));
+        ccnl_nfnprefix_clear(copy, CCNL_PREFIX_NFN | CCNL_PREFIX_THUNK);
+        if (!ccnl_nfn_local_content_search(ccnl, NULL, copy)) {
+            free_prefix(copy);
+            ccnl_interest_propagate(ccnl, interest);
+            return 0;
+        }
+        free_prefix(copy);
+        start_locally = 1;
+    }
+
+    //put packet together
+#if defined(USE_SUITE_CCNTLV) || defined(USE_SUITE_CISTLV)
+    if (prefix->suite == CCNL_SUITE_CCNTLV
+            || prefix->suite == CCNL_SUITE_CISTLV) {
+        offset = 4;
+    }
+#endif
+    ccnl_snprintf(&tmpStr, &remLen, &totalLen, "%.*s",
+        prefix->complen[prefix->compcnt-1] - offset,
+        prefix->comp[prefix->compcnt-1] + offset);
+
+    if (prefix->compcnt > 1)
+        ccnl_snprintf(&tmpStr, &remLen, &totalLen, " ");
+
+    for (i = 0; i < prefix->compcnt-1; i++) {
+        ccnl_snprintf(&tmpStr, &remLen, &totalLen, "/%.*s",
+            prefix->complen[i] - offset,
+            prefix->comp[i] + offset);
+    }
+
+    DEBUGMSG(DEBUG, "expr is <%s>\n", str);
+    //search for result here... if found return...
+    if (thunk_request)
+        num_of_required_thunks = ccnl_nfn_count_required_thunks(str);
+
+    ++ccnl->km->numOfRunningComputations;
+restart:
+    res = Krivine_reduction(ccnl, str, thunk_request, start_locally,
+                            num_of_required_thunks, &config, prefix, suite);
+
+    //stores result if computed
+    if (res && res->datalen > 0) {
+        struct ccnl_prefix_s *copy;
+        struct ccnl_content_s *c;
+
+        DEBUGMSG(INFO,"Computation finished: res: %.*s size: %d bytes. Running computations: %d\n",
+                 res->datalen, res->data, res->datalen, ccnl->km->numOfRunningComputations);
+        if (config && config->fox_state->thunk_request) {
+            // ccnl_nfn_remove_thunk_from_prefix(config->prefix);
+            ccnl_nfnprefix_clear(config->prefix, CCNL_PREFIX_THUNK);
+        }
+        copy = ccnl_prefix_dup(config->prefix);
+        c = ccnl_nfn_result2content(ccnl, &copy, res->data, res->datalen);
+        c->flags = CCNL_CONTENT_FLAGS_STATIC;
+
+        set_propagate_of_interests_to_1(ccnl, c->pkt->pfx);
+        ccnl_content_serve_pending(ccnl,c);
+        ccnl_content_add2cache(ccnl, c);
+        --ccnl->km->numOfRunningComputations;
+
+        DBL_LINKED_LIST_REMOVE(ccnl->km->configuration_list, config);
+        ccnl_nfn_freeConfiguration(config);
+        ccnl_free(res);
+    }
+#ifdef USE_NACK
+    else if(config->local_done){
+        struct ccnl_content_s *nack;
+        nack = ccnl_nfn_result2content(ccnl, &config->prefix,
+                                       (unsigned char*)":NACK", 5);
+        ccnl_content_serve_pending(ccnl, nack);
+
+    }
+#endif
+
+    TRACEOUT();
+    return 0;
+}
+
+struct ccnl_interest_s*
+ccnl_nfn_RX_request(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
+                     struct ccnl_pkt_s **pkt)
+{
+    struct ccnl_interest_s *i;
+
+    if (!ccnl_nfnprefix_isNFN((*pkt)->pfx) ||
+           ccnl->km->numOfRunningComputations >= NFN_MAX_RUNNING_COMPUTATIONS)
+        return NULL;
+    i = ccnl_interest_new(ccnl, from, pkt);
+    if (!i)
+        return NULL;
+    i->flags &= ~CCNL_PIT_COREPROPAGATES; // do not forward interests for running computations
+    ccnl_interest_append_pending(i, from);
+//    if (!(i->flags & CCNL_PIT_COREPROPAGATES))
+    ccnl_nfn(ccnl, ccnl_prefix_dup(i->pkt->pfx), from, NULL, i, i->pkt->suite, 0);
+
+    TRACEOUT();
+    return i;
+}
+
+
+int
+ccnl_nfn_RX_result(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
+                   struct ccnl_content_s *c)
+{
+    struct ccnl_interest_s *i_it = NULL;
+    int found = 0;
+    char prefixBuf[CCNL_PREFIX_BUFSIZE];
+
+    DEBUGMSG_CFWD(INFO, "data in rx result %.*s\n", c->pkt->contlen, c->pkt->content);
+    TRACEIN();
+#ifdef USE_NACK
+    if (ccnl_nfnprefix_contentIsNACK(c)) {
+        ccnl_nfn_nack_local_computation(relay, c->pkt->buf, c->pkt->pfx,
+                                        from, c->pkt->pfx->suite);
+        return -1;
+    }
+#endif // USE_NACK
+    for (i_it = relay->pit; i_it;/* i_it = i_it->next*/) {
+        //Check if prefix match and it is a nfn request
+        if (!ccnl_prefix_cmp(c->pkt->pfx, NULL, i_it->pkt->pfx, CMP_EXACT) &&
+                                        i_it->from && i_it->from->faceid < 0) {
+            struct ccnl_face_s *from2 = i_it->from;
+            int faceid = - from2->faceid;
+
+            DEBUGMSG(TRACE, "  interest faceid=%d\n", i_it->from->faceid);
+
+            ccnl_content_add2cache(relay, c);
+	    DEBUGMSG_CFWD(INFO, "data in rx resulti after add to cache %.*s\n", c->pkt->contlen, c->pkt->content);
+            DEBUGMSG(DEBUG, "Continue configuration for configid: %d with prefix: %s\n",
+                     faceid,
+                     ccnl_prefix2path(prefixBuf, CCNL_ARRAY_SIZE(prefixBuf), c->pkt->pfx));
+            i_it->flags |= CCNL_PIT_COREPROPAGATES;
+            i_it->from = NULL;
+            ccnl_nfn_continue_computation(relay, faceid, 0);
+            i_it = ccnl_interest_remove(relay, i_it);
+<<<<<<< HEAD
+            ccnl_face_remove(relay, from2);
+=======
+            //ccnl_face_remove(relay, from);
+>>>>>>> default_source
+            ++found;
+            //goto Done;
+        } else
+            i_it = i_it->next;
+    }
+    TRACEOUT();
+    return found > 0;
+}
+
+#endif //USE_NFN
+
+
+// eof

--- a/src/ccnl-pkt-ccntlv.c
+++ b/src/ccnl-pkt-ccntlv.c
@@ -40,7 +40,7 @@ Note:
 // convert network order byte array into local unsigned integer value
 int
 ccnl_ccnltv_extractNetworkVarInt(unsigned char *buf, int len,
-                                 unsigned int *intval)
+                                 int *intval)
 {
     int val = 0;
 
@@ -70,7 +70,7 @@ ccnl_ccntlv_getHdrLen(unsigned char *data, int len)
 // parse TL (returned in typ and vallen) and adjust buf and len
 int
 ccnl_ccntlv_dehead(unsigned char **buf, int *len,
-                   unsigned int *typ, unsigned int *vallen)
+                   unsigned int *typ, int *vallen)
 {
 // Avoiding casting pointers to uint16t -- issue with the RFduino compiler?
 // Workaround:
@@ -106,8 +106,8 @@ struct ccnl_pkt_s*
 ccnl_ccntlv_bytes2pkt(unsigned char *start, unsigned char **data, int *datalen)
 {
     struct ccnl_pkt_s *pkt;
-    int i;
-    unsigned int len, typ, oldpos;
+    int i, len;
+    unsigned int typ, oldpos;
     struct ccnl_prefix_s *p;
 #ifdef USE_HMAC256
     int validAlgoIsHmac256 = 0;
@@ -145,7 +145,7 @@ ccnl_ccntlv_bytes2pkt(unsigned char *start, unsigned char **data, int *datalen)
     while (ccnl_ccntlv_dehead(data, datalen, &typ, &len) == 0) {
         unsigned char *cp = *data, *cp2;
         int len2 = len;
-        unsigned int len3;
+        int len3;
 
         if ( (int)len > *datalen)
             goto Bail;
@@ -164,7 +164,7 @@ ccnl_ccntlv_bytes2pkt(unsigned char *start, unsigned char **data, int *datalen)
                     // possibly want to remove the chunk segment from the
                     // name components and rely on the chunknum field in
                     // the prefix.
-                  p->chunknum = (unsigned int*) ccnl_malloc(sizeof(int));
+                  p->chunknum = (int*) ccnl_malloc(sizeof(int));
 
                     if (ccnl_ccnltv_extractNetworkVarInt(cp, len3,
                                                          p->chunknum) < 0) {
@@ -213,7 +213,7 @@ ccnl_ccntlv_bytes2pkt(unsigned char *start, unsigned char **data, int *datalen)
             break;
         case CCNX_TLV_M_ENDChunk:
             if (ccnl_ccnltv_extractNetworkVarInt(cp, len,
-                              (unsigned int*) &(pkt->val.final_block_id)) < 0) {
+                              (int*) &(pkt->val.final_block_id)) < 0) {
                 DEBUGMSG_PCNX(WARNING, "error when extracting CCNX_TLV_M_ENDChunk\n");
                 goto Bail;
             }

--- a/src/ccnl-pkt-cistlv.c
+++ b/src/ccnl-pkt-cistlv.c
@@ -30,7 +30,7 @@
 // convert network order byte array into local unsigned integer value
 int
 ccnl_cistlv_extractNetworkVarInt(unsigned char *buf, int len,
-                                 unsigned int *intval)
+                                 int *intval)
 {
     int val = 0;
 
@@ -123,7 +123,7 @@ ccnl_cistlv_bytes2pkt(unsigned char *start, unsigned char **data, int *datalen)
                     // We extract the chunknum to the prefix but keep it in the name component for now
                     // In the future we possibly want to remove the chunk segment from the name components
                     // and rely on the chunknum field in the prefix.
-                  p->chunknum = (unsigned int*) ccnl_malloc(sizeof(int));
+                  p->chunknum = (int*) ccnl_malloc(sizeof(int));
 
                     if (ccnl_cistlv_extractNetworkVarInt(cp,
                                                          len2, p->chunknum) < 0) {
@@ -161,7 +161,7 @@ ccnl_cistlv_bytes2pkt(unsigned char *start, unsigned char **data, int *datalen)
             break;
         case CISCO_TLV_FinalSegmentID:
             if (ccnl_cistlv_extractNetworkVarInt(cp, len2,
-                               (unsigned int*) &pkt->val.final_block_id) < 0) {
+                               (int*) &pkt->val.final_block_id) < 0) {
                     DEBUGMSG(WARNING, "error when extracting CISCO_TLV_FinalSegmentID\n");
                     goto Bail;
             }

--- a/src/ccnl-pkt-iottlv.c
+++ b/src/ccnl-pkt-iottlv.c
@@ -68,7 +68,7 @@ ccnl_iottlv_peekType(unsigned char *buf, int len)
 // parse TL (returned in typ and vallen) and adjust buf and len
 int
 ccnl_iottlv_dehead(unsigned char **buf, int *len,
-                   unsigned int *typ, unsigned int *vallen)
+                   unsigned int *typ, int *vallen)
 {
     if (*len < 1)
         return -1;
@@ -92,7 +92,8 @@ struct ccnl_prefix_s *
 ccnl_iottlv_parseHierarchicalName(unsigned char *data, int datalen)
 {
     int len = datalen;
-    unsigned int typ, len2;
+    unsigned int typ;
+    int len2;
     struct ccnl_prefix_s *p;
 
     p = (struct ccnl_prefix_s *) ccnl_calloc(1, sizeof(struct ccnl_prefix_s));
@@ -146,8 +147,8 @@ ccnl_iottlv_bytes2pkt(int pkttype, unsigned char *start,
 {
     struct ccnl_pkt_s *pkt;
     unsigned char *cp, tmp[10];
-    int cplen, len2;
-    unsigned int typ, len, state;
+    int cplen, len, len2;
+    unsigned int typ, state;
 
     DEBUGMSG_PIOT(DEBUG, "ccnl_iottlv_extract len=%d\n", *datalen);
     /*
@@ -179,7 +180,7 @@ ccnl_iottlv_bytes2pkt(int pkttype, unsigned char *start,
         {
             cp = *data;
             cplen = len;
-            while (cplen > 0 && !ccnl_iottlv_dehead(&cp, &cplen, &typ, (unsigned int *)&len2)) {
+            while (cplen > 0 && !ccnl_iottlv_dehead(&cp, &cplen, &typ, &len2)) {
                 if (typ == IOT_TLV_H_HopLim && len2 == 1) {
                     if (*cp > 0)
                         *cp -= 1;
@@ -195,7 +196,7 @@ ccnl_iottlv_bytes2pkt(int pkttype, unsigned char *start,
         case IOTPS(IOT_TLV_Reply, IOT_TLV_R_Name):
             cp = *data;
             cplen = len;
-            while (cplen > 0 && !ccnl_iottlv_dehead(&cp, &cplen, &typ, (unsigned int *)&len2)) {
+            while (cplen > 0 && !ccnl_iottlv_dehead(&cp, &cplen, &typ, &len2)) {
                 if (typ == IOT_TLV_N_PathName) {
                     if (!pkt->pfx)
                         pkt->pfx = ccnl_iottlv_parseHierarchicalName(cp, len2);
@@ -223,7 +224,7 @@ ccnl_iottlv_bytes2pkt(int pkttype, unsigned char *start,
         case IOTPS(IOT_TLV_Reply, IOT_TLV_R_Payload):
             cp = *data;
             cplen = len;
-            if (!ccnl_iottlv_dehead(&cp, &cplen, &typ, (unsigned int *)&len2)) {
+            if (!ccnl_iottlv_dehead(&cp, &cplen, &typ, &len2)) {
                 if (typ == IOT_TLV_PL_Data) {
                     pkt->content = cp;
                     pkt->contlen = len2;

--- a/src/ccnl-pkt-ndntlv.c
+++ b/src/ccnl-pkt-ndntlv.c
@@ -65,7 +65,7 @@ ccnl_ndntlv_nonNegInt(unsigned char *cp, int len)
 
 int
 ccnl_ndntlv_dehead(unsigned char **buf, int *len,
-                   unsigned int *typ, unsigned int *vallen)
+                   unsigned int *typ, int *vallen)
 {
   if (ccnl_ndntlv_varlenint(buf, len, (int*) typ))
         return -1;
@@ -80,8 +80,8 @@ ccnl_ndntlv_bytes2pkt(unsigned int pkttype, unsigned char *start,
                       unsigned char **data, int *datalen)
 {
     struct ccnl_pkt_s *pkt;
-    int oldpos;
-    unsigned int i, typ, len;
+    int oldpos, len, i;
+    unsigned int typ;
     struct ccnl_prefix_s *p = 0;
 #ifdef USE_HMAC256
     int validAlgoIsHmac256 = 0;
@@ -142,7 +142,7 @@ ccnl_ndntlv_bytes2pkt(unsigned int pkttype, unsigned char *start,
                 if (typ == NDN_TLV_NameComponent &&
                             p->compcnt < CCNL_MAX_NAME_COMP) {
                     if(cp[0] == NDN_Marker_SegmentNumber) {
-                      p->chunknum = (unsigned int*) ccnl_malloc(sizeof(int));
+                      p->chunknum = (int*) ccnl_malloc(sizeof(int));
                         // TODO: requires ccnl_ndntlv_includedNonNegInt which includes the length of the marker
                         // it is implemented for encode, the decode is not yet implemented
                         *p->chunknum = ccnl_ndntlv_nonNegInt(cp + 1, i - 1);

--- a/src/util/ccn-lite-ctrl.c
+++ b/src/util/ccn-lite-ctrl.c
@@ -668,7 +668,8 @@ getPrefix(unsigned char *data, int datalen, int *suite)
     }
     case CCNL_SUITE_IOTTLV: {
         unsigned char *start = data - skip;
-        unsigned int typ, len;
+        unsigned int typ;
+        int len;
 
         if (!ccnl_iottlv_dehead(&data, &datalen, &typ, &len) &&
                                                         typ == IOT_TLV_Reply)
@@ -676,7 +677,8 @@ getPrefix(unsigned char *data, int datalen, int *suite)
         break;
     }
     case CCNL_SUITE_NDNTLV: {
-        unsigned int typ, len;
+        unsigned int typ;
+        int len;
         unsigned char *start = data;
         if (!ccnl_ndntlv_dehead(&data, &datalen, &typ, &len))
             pkt = ccnl_ndntlv_bytes2pkt(typ, start, &data, &datalen);

--- a/src/util/ccn-lite-fetch.c
+++ b/src/util/ccn-lite-fetch.c
@@ -134,7 +134,8 @@ ccnl_extractDataAndChunkInfo(unsigned char **data, int *datalen,
 #endif
 #ifdef USE_SUITE_NDNTLV
     case CCNL_SUITE_NDNTLV: {
-        unsigned int typ, len;
+        unsigned int typ;
+        int len;
         unsigned char *start = *data;
 
         if (ccnl_ndntlv_dehead(data, datalen, &typ, &len)) {

--- a/src/util/ccn-lite-mkF.c
+++ b/src/util/ccn-lite-mkF.c
@@ -61,7 +61,7 @@ file2frags(int suite, unsigned char *data, int datalen, char *fileprefix,
         if (noclobber && !access(fname, F_OK)) {
             printf("file %s already exists, skipping this name\n", fname);
         } else {
-            printf("new fragment, len=%d / %d --> %s\n",
+            printf("new fragment, len=%zd / %d --> %s\n",
                    fragbuf->datalen, fr.sendseq, fname);
             f = creat(fname, 0666);
             if (f < 0)

--- a/src/util/ccn-lite-peek.c
+++ b/src/util/ccn-lite-peek.c
@@ -211,7 +211,8 @@ usage:
 
 #ifdef USE_FRAG
             if (isFragment && isFragment(cp, len2)) {
-                unsigned int t, len3;
+                unsigned int t;
+                int len3;
                 DEBUGMSG(DEBUG, "  fragment, %d bytes\n", len2);
                 switch(suite) {
                 case CCNL_SUITE_CCNTLV: {

--- a/src/util/ccn-lite-pktdump.c
+++ b/src/util/ccn-lite-pktdump.c
@@ -491,8 +491,8 @@ static int
 ccntlv_parse_sequence(int lev, unsigned char ctx, unsigned char *base,
               unsigned char **buf, int *len, char *cur_tag, int rawxml, FILE* out)
 {
-    unsigned int vallen, typ;
-    int i;
+    unsigned int typ;
+    int i, vallen;
     unsigned char ctx2, *cp;
     char *n, n_old[100], tmp[100];
 
@@ -1102,8 +1102,8 @@ iottlv_parse_sequence(int lev, unsigned char ctx, unsigned char *base,
                       unsigned char **buf, int *len, char *cur_tag,
                       int rawxml, FILE* out)
 {
-    int i;
-    unsigned int vallen, typ;
+    int i, vallen;
+    unsigned int typ;
     unsigned char ctx2, *cp;
     char *n, n_old[100], tmp[100];
 
@@ -1233,10 +1233,10 @@ ndn_type2name(unsigned type)
 
 static int
 ndn_parse_sequence(int lev, unsigned char *base, unsigned char **buf,
-               unsigned int *len, char *cur_tag, int rawxml, FILE* out)
+               int *len, char *cur_tag, int rawxml, FILE* out)
 {
-    int i, maxi;
-    unsigned int typ, vallen;
+    int i, maxi, vallen;
+    unsigned int typ;
     unsigned char *cp;
     char *n, tmp[100];
 
@@ -1329,7 +1329,7 @@ ndn_parse_sequence(int lev, unsigned char *base, unsigned char **buf,
 }
 
 static void
-ndntlv_201311(unsigned char *data, unsigned int len, int rawxml, FILE* out)
+ndntlv_201311(unsigned char *data, int len, int rawxml, FILE* out)
 {
     unsigned char *buf = data;
 
@@ -1512,7 +1512,8 @@ emit_content_only(unsigned char *start, int len, int suite, int format)
         break;
     }
     case CCNL_SUITE_IOTTLV: {
-        unsigned int pkttype, vallen;
+        unsigned int pkttype;
+        int vallen;
         data = start;
         if (ccnl_iottlv_dehead(&data, &len, &pkttype, &vallen) < 0)
             return -1;
@@ -1520,7 +1521,8 @@ emit_content_only(unsigned char *start, int len, int suite, int format)
         break;
     }
     case CCNL_SUITE_NDNTLV: {
-        unsigned int pkttype, vallen;
+        unsigned int pkttype;
+        int vallen;
         data = start;
         if (ccnl_ndntlv_dehead(&data, &len, &pkttype, &vallen) < 0)
             return -1;

--- a/src/util/ccn-lite-valid.c
+++ b/src/util/ccn-lite-valid.c
@@ -80,7 +80,8 @@ ccnl_parse(unsigned char *data, int datalen)
 #endif
 #ifdef USE_SUITE_NDNTLV
     case CCNL_SUITE_NDNTLV: {
-        unsigned int typ, len2;
+        unsigned int typ;
+        int len2;
 
         if (ccnl_ndntlv_dehead(&data, &datalen, &typ, &len2)) {
             DEBUGMSG(FATAL, "ndn2013: parse error\n");

--- a/src/util/ccnl-common.c
+++ b/src/util/ccnl-common.c
@@ -358,7 +358,8 @@ iottlv_mkRequest(struct ccnl_prefix_s *name, int *dummy,
 int iottlv_isReply(unsigned char *buf, int len)
 {
     int enc = 1, suite;
-    unsigned int typ, vallen;
+    unsigned int typ;
+    int vallen;
 
     while (!ccnl_switch_dehead(&buf, &len, &enc));
     suite = ccnl_enc2suite(enc);
@@ -407,7 +408,8 @@ ndntlv_mkInterest(struct ccnl_prefix_s *name, int *nonce,
 
 int ndntlv_isData(unsigned char *buf, int len)
 {
-    unsigned int typ, vallen;
+    unsigned int typ;
+    int vallen;
 
     if (len < 0 || ccnl_ndntlv_dehead(&buf, &len, &typ, &vallen))
         return -1;


### PR DESCRIPTION
Some struct members are used with a negative value to indicate error cases but were defined as unsigned variables. This PR fixes this.