### PR TITLE
FIB helper functions

### DIFF
--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -326,6 +326,20 @@ ccnl_start(void)
     return _ccnl_event_loop_pid;
 }
 
+char*
+ll2ascii(unsigned char *addr)
+{
+    static char buf[24];
+
+    sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x",
+            (unsigned char) addr[0], (unsigned char) addr[1],
+            (unsigned char) addr[2], (unsigned char) addr[3],
+            (unsigned char) addr[4], (unsigned char) addr[5],
+            (unsigned char) addr[6], (unsigned char) addr[7]);
+    return buf;
+}
+
+
 int
 ccnl_add_fib_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
                    struct ccnl_face_s *face)

--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -326,53 +326,62 @@ ccnl_start(void)
     return _ccnl_event_loop_pid;
 }
 
-char*
-ll2ascii(unsigned char *addr)
-{
-    static char buf[24];
-
-    sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x",
-            (unsigned char) addr[0], (unsigned char) addr[1],
-            (unsigned char) addr[2], (unsigned char) addr[3],
-            (unsigned char) addr[4], (unsigned char) addr[5],
-            (unsigned char) addr[6], (unsigned char) addr[7]);
-    return buf;
-}
-
-
 int
-ccnl_add_fib_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
-                   struct ccnl_face_s *face)
+ccnl_wait_for_chunk(void *buf, size_t buf_len)
 {
-    struct ccnl_forward_s *fwd, **fwd2;
+    gnrc_netreg_entry_t _ne;
+    /* register for content chunks */
+    _ne.demux_ctx =  GNRC_NETREG_DEMUX_CTX_ALL;
+    _ne.pid = sched_active_pid;
+    gnrc_netreg_register(GNRC_NETTYPE_CCN_CHUNK, &_ne);
 
-    DEBUGMSG_CFWD(INFO, "adding FIB for <%s>, suite %s\n",
-             ccnl_prefix_to_path(pfx), ccnl_suite2str(pfx->suite));
+    int res = (-1);
 
-    for (fwd = relay->fib; fwd; fwd = fwd->next) {
-        if (fwd->suite == pfx->suite &&
-                        !ccnl_prefix_cmp(fwd->prefix, NULL, pfx, CMP_EXACT)) {
-            free_prefix(fwd->prefix);
-            fwd->prefix = NULL;
+    while (1) { /* wait for a content pkt (ignore interests) */
+        DEBUGMSG(DEBUG, "  waiting for packet\n");
+
+        /* TODO: receive from socket or interface */
+        msg_t m;
+        if (xtimer_msg_receive_timeout(&m, SEC_IN_USEC) >= 0) {
+            DEBUGMSG(DEBUG, "received something\n");
+        }
+        else {
+            /* TODO: handle timeout reasonably */
+            DEBUGMSG(WARNING, "timeout\n");
+            res = -ETIMEDOUT;
             break;
         }
-    }
-    if (!fwd) {
-        fwd = (struct ccnl_forward_s *) ccnl_calloc(1, sizeof(*fwd));
-        if (!fwd)
-            return -1;
-        fwd2 = &relay->fib;
-        while (*fwd2)
-            fwd2 = &((*fwd2)->next);
-        *fwd2 = fwd;
-        fwd->suite = pfx->suite;
-    }
-    fwd->prefix = pfx;
-    fwd->face = face;
 
-    return 0;
+        if (m.type == GNRC_NETAPI_MSG_TYPE_RCV) {
+            DEBUGMSG(TRACE, "It's from the stack!\n");
+            gnrc_pktsnip_t *pkt = (gnrc_pktsnip_t *)m.content.ptr;
+            DEBUGMSG(DEBUG, "Type is: %i\n", pkt->type);
+            if (pkt->type == GNRC_NETTYPE_CCN_CHUNK) {
+                char *c = (char*) pkt->data;
+                DEBUGMSG(INFO, "Content is: %s\n", c);
+                size_t len = (pkt->size > buf_len) ? buf_len : pkt->size;
+                memcpy(buf, pkt->data, len);
+                res = (int) len;
+                gnrc_pktbuf_release(pkt);
+            }
+            else {
+                DEBUGMSG(WARNING, "Unkown content\n");
+                gnrc_pktbuf_release(pkt);
+                continue;
+            }
+            break;
+        }
+        else {
+            /* TODO: reduce timeout value */
+            DEBUGMSG(DEBUG, "Unknow message received, ignore it\n");
+        }
+    }
+
+    /* unregister again, we're not expecting more chunks */
+    gnrc_netreg_unregister(GNRC_NETTYPE_CCN_CHUNK, &_ne);
+
+    return res;
 }
-
 
 int
 ccnl_send_interest(int suite, char *name, uint8_t *addr,
@@ -439,60 +448,4 @@ ccnl_send_interest(int suite, char *name, uint8_t *addr,
     ccnl_interest_propagate(&theRelay, i);
 
     return 0;
-}
-
-int
-ccnl_wait_for_chunk(void *buf, size_t buf_len)
-{
-    /* register for content chunks */
-    _ne.demux_ctx =  GNRC_NETREG_DEMUX_CTX_ALL;
-    _ne.pid = sched_active_pid;
-    gnrc_netreg_register(GNRC_NETTYPE_CCN_CHUNK, &_ne);
-
-    int res = (-1);
-
-    while (1) { /* wait for a content pkt (ignore interests) */
-        DEBUGMSG(DEBUG, "  waiting for packet\n");
-
-        /* TODO: receive from socket or interface */
-        msg_t m;
-        if (xtimer_msg_receive_timeout(&m, SEC_IN_USEC) >= 0) {
-            DEBUGMSG(DEBUG, "received something\n");
-        }
-        else {
-            /* TODO: handle timeout reasonably */
-            DEBUGMSG(WARNING, "timeout\n");
-            res = -ETIMEDOUT;
-            break;
-        }
-
-        if (m.type == GNRC_NETAPI_MSG_TYPE_RCV) {
-            DEBUGMSG(TRACE, "It's from the stack!\n");
-            gnrc_pktsnip_t *pkt = (gnrc_pktsnip_t *)m.content.ptr;
-            DEBUGMSG(DEBUG, "Type is: %i\n", pkt->type);
-            if (pkt->type == GNRC_NETTYPE_CCN_CHUNK) {
-                char *c = (char*) pkt->data;
-                DEBUGMSG(INFO, "Content is: %s\n", c);
-                size_t len = (pkt->size > buf_len) ? buf_len : pkt->size;
-                memcpy(buf, pkt->data, len);
-                res = (int) len;
-                gnrc_pktbuf_release(pkt);
-            }
-            else {
-                DEBUGMSG(WARNING, "Unkown content\n");
-                gnrc_pktbuf_release(pkt);
-                continue;
-            }
-            break;
-        }
-        else {
-            /* TODO: reduce timeout value */
-            DEBUGMSG(DEBUG, "Unknow message received, ignore it\n");
-        }
-    }
-
-    /* unregister again, we're not expecting more chunks */
-    gnrc_netreg_unregister(GNRC_NETTYPE_CCN_CHUNK, &_ne);
-
-    return res;
 }

--- a/src/ccnl-core-util.c
+++ b/src/ccnl-core-util.c
@@ -855,6 +855,28 @@ free_packet(struct ccnl_pkt_s *pkt)
 
 // ----------------------------------------------------------------------
 
+/* translates link-layer address into a string */
+char*
+ll2ascii(unsigned char *addr)
+{
+    static char buf[CCNL_LLADDR_STR_MAX_LEN];
+
+#ifdef CCNL_ARDUINO
+    sprintf_P(buf, PSTR("%02x"), (unsigned char) addr[0]);
+#else
+    sprintf(buf, "%02x", (unsigned char) addr[0]);
+#endif
+    for (int i = 1; i < CCNL_LLADDR_STR_MAX_LEN; i++) {
+#ifdef CCNL_ARDUINO
+        sprintf_P(&buf[i], PSTR(":%02x"), (unsigned char) addr[i]);
+#else
+        sprintf(&buf[i], ":%02x", (unsigned char) addr[i]);
+#endif
+    }
+
+    return buf;
+}
+
 char*
 ccnl_addr2ascii(sockunion *su)
 {
@@ -869,15 +891,13 @@ ccnl_addr2ascii(sockunion *su)
 
     switch (su->sa.sa_family) {
 #ifdef USE_LINKLAYER
-#ifdef USE_DEBUG
     case AF_PACKET: {
         struct sockaddr_ll *ll = &su->linklayer;
-        strcpy(result, eth2ascii(ll->sll_addr));
+        strcpy(result, ll2ascii(ll->sll_addr));
         sprintf(result+strlen(result), "/0x%04x",
             ntohs(ll->sll_protocol));
         return result;
     }
-#endif
 #endif
 #ifdef USE_IPV4
     case AF_INET:

--- a/src/ccnl-core.h
+++ b/src/ccnl-core.h
@@ -42,6 +42,13 @@
 #define CCNL_FRAG_SEQUENCED2015 3
 #define CCNL_FRAG_BEGINEND2015  4
 
+#ifdef CCNL_RIOT
+#define CCNL_LLADDR_STR_MAX_LEN    (3 * 8)
+#else
+/* unless a platform supports a link layer with longer addresses than Ethernet,
+ * 6 is enough */
+#define CCNL_LLADDR_STR_MAX_LEN    (3 * 6)
+#endif
 // ----------------------------------------------------------------------
 
 typedef union {

--- a/src/ccnl-ext-debug.c
+++ b/src/ccnl-ext-debug.c
@@ -61,25 +61,6 @@ void jni_append_to_log(char *line);
 // ----------------------------------------------------------------------
 #ifdef USE_DEBUG
 
-char*
-eth2ascii(unsigned char *eth)
-{
-    static char buf[18];
-
-#ifdef CCNL_ARDUINO
-    sprintf_P(buf, PSTR("%02x:%02x:%02x:%02x:%02x:%02x"),
-          (unsigned char) eth[0], (unsigned char) eth[1],
-          (unsigned char) eth[2], (unsigned char) eth[3],
-          (unsigned char) eth[4], (unsigned char) eth[5]);
-#else
-    sprintf(buf, "%02x:%02x:%02x:%02x:%02x:%02x",
-          (unsigned char) eth[0], (unsigned char) eth[1],
-          (unsigned char) eth[2], (unsigned char) eth[3],
-          (unsigned char) eth[4], (unsigned char) eth[5]);
-#endif
-    return buf;
-}
-
 char* ccnl_addr2ascii(sockunion *su);
 
 // ----------------------------------------------------------------------

--- a/src/ccnl-headers.h
+++ b/src/ccnl-headers.h
@@ -233,7 +233,8 @@ int ccnl_lambdaStrToComponents(char **compVector, char *str);
 struct ccnl_buf_s *ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, int *nonce);
 struct ccnl_buf_s *ccnl_mkSimpleContent(struct ccnl_prefix_s *name, unsigned char *payload, int paylen, int *payoffset);
 int ccnl_str2suite(char *cp);
-
+int ccnl_add_fib_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx, struct ccnl_face_s *face);
+void ccnl_show_fib(struct ccnl_relay_s *relay);
 
 //---------------------------------------------------------------------------------------------------------------------------------------
 /* fwd-ccnb.c */


### PR DESCRIPTION
This PR provides two utility functions to interact with the FIB:
* `ccnl_add_fib_entry()` adds a new entry to the FIB
* `ccnl_show_fib()` prints the current FIB to stdout

Additional, this PR makes the printing of link-layer addresses more generic and not only working for Ethernet addresses.