### PR TITLE
free memory from debug output

### DIFF
--- a/src/ccnl-core-fwd.c
+++ b/src/ccnl-core-fwd.c
@@ -27,19 +27,21 @@ ccnl_fwd_handleContent(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
 {
     struct ccnl_content_s *c;
 
+    char *s = NULL;
 #ifdef USE_NFN
     DEBUGMSG_CFWD(INFO, "  incoming data=<%s>%s (nfnflags=%d) from=%s\n",
-                  ccnl_prefix_to_path((*pkt)->pfx),
+                  (s = ccnl_prefix_to_path((*pkt)->pfx)),
                   ccnl_suite2str((*pkt)->suite),
                   (*pkt)->pfx->nfnflags,
                   ccnl_addr2ascii(from ? &from->peer : NULL));
     DEBUGMSG_CFWD(INFO, "data %.*s\n", (*pkt)->contlen, (*pkt)->content);
 #else
     DEBUGMSG_CFWD(INFO, "  incoming data=<%s>%s from=%s\n",
-                  ccnl_prefix_to_path((*pkt)->pfx),
+                  (s = ccnl_prefix_to_path((*pkt)->pfx)),
                   ccnl_suite2str((*pkt)->suite),
                   ccnl_addr2ascii(from ? &from->peer : NULL));
 #endif
+    ccnl_free(s);
 
 #if defined(USE_SUITE_CCNB) && defined(USE_SIGNATURES)
 //  FIXME: mgmt messages for NDN and other suites?
@@ -140,10 +142,12 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     struct ccnl_interest_s *i;
     struct ccnl_content_s *c;
 
+    char *s = NULL;
     DEBUGMSG_CFWD(INFO, "  incoming interest=<%s>%s from=%s\n",
-                  ccnl_prefix_to_path((*pkt)->pfx),
+                  (s = ccnl_prefix_to_path((*pkt)->pfx)),
                   ccnl_suite2str((*pkt)->suite),
                   ccnl_addr2ascii(from ? &from->peer : NULL));
+    ccnl_free(s);
 
     if (ccnl_nonce_isDup(relay, *pkt)) {
         DEBUGMSG_CFWD(DEBUG, "  dropped because of duplicate nonce\n");
@@ -205,17 +209,19 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     if (!i) {
         i = ccnl_interest_new(relay, from, pkt);
 
+    char *s = NULL;
 #ifdef USE_NFN
         DEBUGMSG_CFWD(DEBUG,
                       "  created new interest entry %p (prefix=%s, nfnflags=%d)\n",
                       (void *) i,
-                      ccnl_prefix_to_path(i->pkt->pfx),
+                      (s = ccnl_prefix_to_path(i->pkt->pfx)),
                       i->pkt->pfx->nfnflags);
 #else
         DEBUGMSG_CFWD(DEBUG,
                       "  created new interest entry %p (prefix=%s)\n",
-                      (void *) i, ccnl_prefix_to_path(i->pkt->pfx));
+                      (void *) i, (s = ccnl_prefix_to_path(i->pkt->pfx)));
 #endif
+    ccnl_free(s);
     }
     if (i) { // store the I request, for the incoming face (Step 3)
         DEBUGMSG_CFWD(DEBUG, "  appending interest entry %p\n", (void *) i);
@@ -694,8 +700,10 @@ ccnl_set_tap(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
 {
     struct ccnl_forward_s *fwd, **fwd2;
 
+    char *s = NULL;
     DEBUGMSG_CFWD(INFO, "setting tap for <%s>, suite %s\n",
-             ccnl_prefix_to_path(pfx), ccnl_suite2str(pfx->suite));
+             (s = ccnl_prefix_to_path(pfx)), ccnl_suite2str(pfx->suite));
+    ccnl_free(s);
 
     for (fwd = relay->fib; fwd; fwd = fwd->next) {
         if (fwd->suite == pfx->suite &&

--- a/src/ccnl-core-util.c
+++ b/src/ccnl-core-util.c
@@ -138,9 +138,12 @@ ccnl_prefix_cmp(struct ccnl_prefix_s *pfx, unsigned char *md,
     int i, clen, plen = pfx->compcnt + (md ? 1 : 0), rc = -1;
     unsigned char *comp;
 
+    char *s1 = NULL, *s2 = NULL;
     DEBUGMSG(VERBOSE, "prefix_cmp(mode=%s) prefix=<%s> of? name=<%s> digest=%p\n",
              ccnl_matchMode2str(mode),
-             ccnl_prefix_to_path(pfx), ccnl_prefix_to_path(nam), (void *) md);
+             (s1 = ccnl_prefix_to_path(pfx)), (s2 = ccnl_prefix_to_path(nam)), (void *) md);
+    ccnl_free(s1);
+    ccnl_free(s2);
 
     if (mode == CMP_EXACT) {
         if (plen != nam->compcnt)
@@ -179,12 +182,14 @@ ccnl_i_prefixof_c(struct ccnl_prefix_s *prefix,
     unsigned char *md;
     struct ccnl_prefix_s *p = c->pkt->pfx;
 
+    char *s1 = NULL, *s2 = NULL;
     DEBUGMSG(VERBOSE, "ccnl_i_prefixof_c prefix=<%s> content=<%s> min=%d max=%d\n",
-             ccnl_prefix_to_path(prefix), ccnl_prefix_to_path(p),
+             (s1 = ccnl_prefix_to_path(prefix)), (s2 = ccnl_prefix_to_path(p)),
              // ccnl_prefix_to_path_detailed(prefix,1,0,0),
              // ccnl_prefix_to_path_detailed(p,1,0,0),
              minsuffix, maxsuffix);
-
+    ccnl_free(s1);
+    ccnl_free(s2);
     // CONFORM: we do prefix match, honour min. and maxsuffix,
 
     // NON-CONFORM: "Note that to match a ContentObject must satisfy
@@ -945,8 +950,10 @@ ccnl_add_fib_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
 {
     struct ccnl_forward_s *fwd, **fwd2;
 
+    char *s = NULL;
     DEBUGMSG_CFWD(INFO, "adding FIB for <%s>, suite %s\n",
-             ccnl_prefix_to_path(pfx), ccnl_suite2str(pfx->suite));
+             (s = ccnl_prefix_to_path(pfx)), ccnl_suite2str(pfx->suite));
+    ccnl_free(s);
 
     for (fwd = relay->fib; fwd; fwd = fwd->next) {
         if (fwd->suite == pfx->suite &&
@@ -989,8 +996,9 @@ ccnl_show_fib(struct ccnl_relay_s *relay)
 #endif
            );
     puts("-------------------------------|------------|-----------|------------------------------------");
+    char *s = NULL;
     for (fwd = relay->fib; fwd; fwd = fwd->next) {
-        printf("%-30s | %-10s |        %02i | %s\n", ccnl_prefix_to_path(fwd->prefix),
+        printf("%-30s | %-10s |        %02i | %s\n", (s = ccnl_prefix_to_path(fwd->prefix)),
                                      ccnl_suite2str(fwd->suite), (int)
                                      /* TODO: show correct interface instead of always 0 */
 #ifdef CCNL_RIOT
@@ -999,6 +1007,7 @@ ccnl_show_fib(struct ccnl_relay_s *relay)
                                      (relay->ifs[0]).sock,
 #endif
                                      ccnl_addr2ascii(&fwd->face->peer));
+        ccnl_free(s);
     }
 }
 
@@ -1191,8 +1200,10 @@ ccnl_mkSimpleContent(struct ccnl_prefix_s *name,
     unsigned char *tmp;
     int len = 0, contentpos = 0, offs;
 
+    char *s = NULL;
     DEBUGMSG_CUTL(DEBUG, "mkSimpleContent (%s, %d bytes)\n",
-             ccnl_prefix_to_path(name), paylen);
+             (s = ccnl_prefix_to_path(name)), paylen);
+    ccnl_free(s);
 
     tmp = (unsigned char*) ccnl_malloc(CCNL_MAX_PACKET_SIZE);
     offs = CCNL_MAX_PACKET_SIZE;

--- a/src/ccnl-core.c
+++ b/src/ccnl-core.c
@@ -390,10 +390,12 @@ ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
 {
     struct ccnl_interest_s *i = (struct ccnl_interest_s *) ccnl_calloc(1,
                                             sizeof(struct ccnl_interest_s));
+    char *s = NULL;
     DEBUGMSG_CORE(TRACE,
                   "ccnl_new_interest(prefix=%s, suite=%s)\n",
-                  ccnl_prefix_to_path((*pkt)->pfx),
+                  (s = ccnl_prefix_to_path((*pkt)->pfx)),
                   ccnl_suite2str((*pkt)->pfx->suite));
+    ccnl_free(s);
 
     if (!i)
         return NULL;
@@ -476,10 +478,12 @@ ccnl_interest_propagate(struct ccnl_relay_s *ccnl, struct ccnl_interest_s *i)
         // suppress forwarding to origin of interest, except wireless
         if (!i->from || fwd->face != i->from ||
                                 (i->from->flags & CCNL_FACE_FLAGS_REFLECT)) {
+            char *s = NULL;
             DEBUGMSG_CFWD(INFO, "  outgoing interest=<%s> to=%s\n",
-                          ccnl_prefix_to_path(i->pkt->pfx),
+                          (s = ccnl_prefix_to_path(i->pkt->pfx)),
                           fwd->face ? ccnl_addr2ascii(&fwd->face->peer)
                                     : "<tap>");
+            ccnl_free(s);
             ccnl_nfn_monitor(ccnl, fwd->face, i->pkt->pfx, NULL, 0);
 
             // DEBUGMSG(DEBUG, "%p %p %p\n", (void*)i, (void*)i->pkt, (void*)i->pkt->buf);
@@ -581,8 +585,10 @@ ccnl_content_new(struct ccnl_relay_s *ccnl, struct ccnl_pkt_s **pkt)
     (void) ccnl;
     struct ccnl_content_s *c;
 
+    char *s = NULL;
     DEBUGMSG_CORE(TRACE, "ccnl_content_new %p <%s [%d]>\n",
-             (void*) *pkt, ccnl_prefix_to_path((*pkt)->pfx), ((*pkt)->pfx->chunknum)? *((*pkt)->pfx->chunknum) : -1);
+             (void*) *pkt, (s = ccnl_prefix_to_path((*pkt)->pfx)), ((*pkt)->pfx->chunknum)? *((*pkt)->pfx->chunknum) : -1);
+    ccnl_free(s);
 
     c = (struct ccnl_content_s *) ccnl_calloc(1, sizeof(struct ccnl_content_s));
     if (!c)
@@ -621,9 +627,11 @@ ccnl_content_add2cache(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
 {
     struct ccnl_content_s *cit;
 
+    char *s = NULL;
     DEBUGMSG_CORE(DEBUG, "ccnl_content_add2cache (%d/%d) --> %p = %s [%d]\n",
                   ccnl->contentcnt, ccnl->max_cache_entries,
-                  (void*)c, ccnl_prefix_to_path(c->pkt->pfx), (c->pkt->pfx->chunknum)? *(c->pkt->pfx->chunknum) : -1);
+                  (void*)c, (s = ccnl_prefix_to_path(c->pkt->pfx)), (c->pkt->pfx->chunknum)? *(c->pkt->pfx->chunknum) : -1);
+    ccnl_free(s);
     for (cit = ccnl->contents; cit; cit = cit->next) {
         if (c == cit) {
             DEBUGMSG_CORE(DEBUG, "--- Already in cache ---\n");
@@ -737,10 +745,12 @@ ccnl_content_serve_pending(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
             continue;
             pi->face->flags |= CCNL_FACE_FLAGS_SERVED;
             if (pi->face->ifndx >= 0) {
+                char *s = NULL;
                 DEBUGMSG_CFWD(INFO, "  outgoing data=<%s>%s to=%s\n",
-                          ccnl_prefix_to_path(i->pkt->pfx),
+                          (s = ccnl_prefix_to_path(i->pkt->pfx)),
                           ccnl_suite2str(i->pkt->pfx->suite),
                           ccnl_addr2ascii(&pi->face->peer));
+                ccnl_free(s);
                 DEBUGMSG_CORE(VERBOSE, "    Serve to face: %d (pkt=%p)\n",
                          pi->face->faceid, (void*) c->pkt);
                 ccnl_nfn_monitor(ccnl, pi->face, c->pkt->pfx,
@@ -781,16 +791,20 @@ ccnl_do_ageing(void *ptr, void *dummy)
                 // than being held indefinitely."
         if ((i->last_used + CCNL_INTEREST_TIMEOUT) <= t ||
                                 i->retries > CCNL_MAX_INTEREST_RETRANSMIT) {
+            char *s = NULL;
             DEBUGMSG_CORE(TRACE, "AGING: INTEREST REMOVE %p\n", (void*) i);
             DEBUGMSG_CORE(DEBUG, " timeout: remove interest 0x%p <%s>\n",
                           (void*)i,
-                     ccnl_prefix_to_path(i->pkt->pfx));
+                     (s = ccnl_prefix_to_path(i->pkt->pfx)));
+            ccnl_free(s);
             i = ccnl_nfn_interest_remove(relay, i);
         } else {
             // CONFORM: "A node MUST retransmit Interest Messages
             // periodically for pending PIT entries."
+            char *s = NULL;
             DEBUGMSG_CORE(DEBUG, " retransmit %d <%s>\n", i->retries,
-                     ccnl_prefix_to_path(i->pkt->pfx));
+                     (s = ccnl_prefix_to_path(i->pkt->pfx)));
+            ccnl_free(s);
 #ifdef USE_NFN
             if (i->flags & CCNL_PIT_COREPROPAGATES){
 #endif


### PR DESCRIPTION
This patch allocates a pointer to store the return value of `ccnl_prefix_to_path()` when called inside a `DEBUGMSG` macro and frees the allocated memory for the output afterwards.

Fixes #50.