### PR TITLE
increase logging level for ageing debug messages

### DIFF
--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -281,7 +281,7 @@ void
     while(!ccnl->halt_flag) {
 
         msg_t m, reply;
-        DEBUGMSG(DEBUG, "ccn-lite: waiting for incoming message.\n");
+        DEBUGMSG(VERBOSE, "ccn-lite: waiting for incoming message.\n");
         int usec = ccnl_run_events();
         if (xtimer_msg_receive_timeout(&m, usec) < 0) {
             continue;

--- a/src/ccnl-core.c
+++ b/src/ccnl-core.c
@@ -766,7 +766,7 @@ ccnl_do_ageing(void *ptr, void *dummy)
     struct ccnl_interest_s *i = relay->pit;
     struct ccnl_face_s *f = relay->faces;
     time_t t = CCNL_NOW();
-    DEBUGMSG_CORE(TRACE, "ageing t=%d\n", (int)t);
+    DEBUGMSG_CORE(VERBOSE, "ageing t=%d\n", (int)t);
 
     while (c) {
         if ((c->last_used + CCNL_CONTENT_TIMEOUT) <= t &&


### PR DESCRIPTION
To prevent being spammed if using a non `VERBOSE` debug level.