### PR TITLE
add the missing 'int sock' for riot

### DIFF
--- a/src/ccnl-core.h
+++ b/src/ccnl-core.h
@@ -86,6 +86,7 @@ struct ccnl_if_s { // interface for packet IO
     EthernetUDP *sock;
 #elif defined(CCNL_RIOT)
     kernel_pid_t if_pid;
+    int sock;
 #else
     int sock;
 #endif


### PR DESCRIPTION
https://github.com/cn-uofbasel/ccn-lite/commit/f394675a1dbfc922005f9729d90c063c8622b53d this commit delete the "int sock" for RIOT