### PR TITLE
RIOT adapter: some updates

### DIFF
--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -277,7 +277,7 @@ void
     ccnl_set_timer(SEC_IN_USEC, ccnl_ageing, ccnl, 0);
 
     /* XXX: https://xkcd.com/221/ */
-    genrand_init(0x4);
+    random_init(0x4);
 
     while(!ccnl->halt_flag) {
 
@@ -412,7 +412,7 @@ ccnl_send_interest(int suite, char *name, uint8_t *addr,
         return -1;
     }
 
-    int nonce = genrand_uint32();
+    int nonce = random_uint32();
     /* TODO: support other transports than AF_PACKET */
     sockunion sun;
     sun.sa.sa_family = AF_PACKET;

--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -131,7 +131,7 @@ ccnl_open_netif(kernel_pid_t if_pid, gnrc_nettype_t netreg_type)
     i->mtu = NDN_DEFAULT_MTU;
     i->fwdalli = 1;
     i->if_pid = if_pid;
-    i->sock = -1;
+    i->addr.sa.sa_family = AF_PACKET;
 
     gnrc_netapi_get(if_pid, NETOPT_MAX_PACKET_SIZE, 0, &(i->mtu), sizeof(i->mtu));
     DEBUGMSG(DEBUG, "interface's MTU is set to %i\n", i->mtu);

--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -138,9 +138,6 @@ ccnl_open_netif(kernel_pid_t if_pid, gnrc_nettype_t netreg_type)
 
     /* advance interface counter in relay */
     theRelay.ifcount++;
-    i = &theRelay.ifs[theRelay.ifcount];
-    i->if_pid = KERNEL_PID_UNDEF;
-    i->sock = -1;
 
     /* configure the interface to use the specified nettype protocol */
     gnrc_netapi_set(if_pid, NETOPT_PROTO, 0, &netreg_type, sizeof(gnrc_nettype_t));

--- a/src/ccnl-core.c
+++ b/src/ccnl-core.c
@@ -217,7 +217,9 @@ ccnl_interface_cleanup(struct ccnl_if_s *i)
         struct ccnl_txrequest_s *r = i->queue + (i->qfront+j)%CCNL_MAX_IF_QLEN;
         ccnl_free(r->buf);
     }
+#ifndef CCNL_RIOT
     ccnl_close_socket(i->sock);
+#endif
 }
 
 // ----------------------------------------------------------------------

--- a/src/ccnl-ext-debug.c
+++ b/src/ccnl-ext-debug.c
@@ -148,7 +148,7 @@ ccnl_dump(int lev, int typ, void *p)
                 CONSOLE(" netdev=%p", top->ifs[k].netdev);
             else
                 CONSOLE(" sockstruct=%p", top->ifs[k].sock);
-#else
+#elif !defined(CCNL_RIOT)
             CONSOLE(" sock=%d", top->ifs[k].sock);
 #endif
             if (top->ifs[k].reflect)


### PR DESCRIPTION
This PR adapts to the fact that f394675a1dbfc922005f9729d90c063c8622b53d removed the sock member from the relay struct when compiling for RIOT. It also prepares for the upcoming API change in RIOT. See https://github.com/RIOT-OS/RIOT/pull/4816.