### PR TITLE
FIB handling: cleanup and remove function

### DIFF
--- a/src/ccnl-core-util.c
+++ b/src/ccnl-core-util.c
@@ -951,7 +951,7 @@ ccnl_fib_add_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
     struct ccnl_forward_s *fwd, **fwd2;
 
     char *s = NULL;
-    DEBUGMSG_CFWD(INFO, "adding FIB for <%s>, suite %s\n",
+    DEBUGMSG_CUTL(INFO, "adding FIB for <%s>, suite %s\n",
              (s = ccnl_prefix_to_path(pfx)), ccnl_suite2str(pfx->suite));
     ccnl_free(s);
 

--- a/src/ccnl-core-util.c
+++ b/src/ccnl-core-util.c
@@ -945,7 +945,7 @@ ccnl_addr2ascii(sockunion *su)
 
 /* add a new entry to the FIB */
 int
-ccnl_add_fib_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
+ccnl_fib_add_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
                    struct ccnl_face_s *face)
 {
     struct ccnl_forward_s *fwd, **fwd2;
@@ -983,7 +983,7 @@ ccnl_add_fib_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
 
 /* prints the current FIB */
 void
-ccnl_show_fib(struct ccnl_relay_s *relay)
+ccnl_fib_show(struct ccnl_relay_s *relay)
 {
 #ifndef CCNL_LINUXKERNEL
     struct ccnl_forward_s *fwd;

--- a/src/ccnl-core-util.c
+++ b/src/ccnl-core-util.c
@@ -979,6 +979,42 @@ ccnl_fib_add_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
     return 0;
 }
 
+/* add a new entry to the FIB */
+int
+ccnl_fib_rem_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
+                   struct ccnl_face_s *face)
+{
+    struct ccnl_forward_s *fwd;
+    int res = -1;
+
+    if (pfx != NULL) {
+        char *s = NULL;
+        DEBUGMSG_CUTL(INFO, "removing FIB for <%s>, suite %s\n",
+                      (s = ccnl_prefix_to_path(pfx)), ccnl_suite2str(pfx->suite));
+        ccnl_free(s);
+    }
+
+    struct ccnl_forward_s *last = NULL;
+    for (fwd = relay->fib; fwd; fwd = fwd->next) {
+        if (((pfx == NULL) || (fwd->suite == pfx->suite)) &&
+            ((pfx == NULL) || !ccnl_prefix_cmp(fwd->prefix, NULL, pfx, CMP_EXACT)) &&
+            ((face == NULL) || (fwd->face == face))) {
+            res = 0;
+            if (last) {
+                last->next = fwd->next;
+            }
+            free_prefix(fwd->prefix);
+            ccnl_free(fwd);
+            relay->fib = NULL;
+            break;
+        }
+    }
+    DEBUGMSG_CUTL(DEBUG, "added FIB via %s\n", ccnl_addr2ascii(&fwd->face->peer));
+
+    return res;
+}
+
+
 #endif
 
 /* prints the current FIB */

--- a/src/ccnl-headers.h
+++ b/src/ccnl-headers.h
@@ -233,6 +233,7 @@ struct ccnl_buf_s *ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, int *nonce)
 struct ccnl_buf_s *ccnl_mkSimpleContent(struct ccnl_prefix_s *name, unsigned char *payload, int paylen, int *payoffset);
 int ccnl_str2suite(char *cp);
 int ccnl_fib_add_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx, struct ccnl_face_s *face);
+int ccnl_fib_rem_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx, struct ccnl_face_s *face);
 void ccnl_fib_show(struct ccnl_relay_s *relay);
 
 //---------------------------------------------------------------------------------------------------------------------------------------

--- a/src/ccnl-headers.h
+++ b/src/ccnl-headers.h
@@ -232,8 +232,8 @@ int ccnl_lambdaStrToComponents(char **compVector, char *str);
 struct ccnl_buf_s *ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, int *nonce);
 struct ccnl_buf_s *ccnl_mkSimpleContent(struct ccnl_prefix_s *name, unsigned char *payload, int paylen, int *payoffset);
 int ccnl_str2suite(char *cp);
-int ccnl_add_fib_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx, struct ccnl_face_s *face);
-void ccnl_show_fib(struct ccnl_relay_s *relay);
+int ccnl_fib_add_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx, struct ccnl_face_s *face);
+void ccnl_fib_show(struct ccnl_relay_s *relay);
 
 //---------------------------------------------------------------------------------------------------------------------------------------
 /* fwd-ccnb.c */


### PR DESCRIPTION
This PR introduces a new function to remove entries from the FIB and updates the function names to match the "correct" pattern.