### PR TITLE
Cache fixes

### DIFF
--- a/src/ccnl-core-fwd.c
+++ b/src/ccnl-core-fwd.c
@@ -81,7 +81,11 @@ ccnl_fwd_handleContent(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     }
     if (relay->max_cache_entries != 0) { // it's set to -1 or a limit
         DEBUGMSG_CFWD(DEBUG, "  adding content to cache\n");
-        ccnl_content_add2cache(relay, c);
+        if (ccnl_content_add2cache(relay, c) == NULL) {
+            DEBUGMSG_CFWD(WARNING, "  adding to cache failed, discard packet\n");
+            free_content(c);
+            return 0;
+        }
     	DEBUGMSG_CFWD(INFO, "data after creating packet %.*s\n", c->pkt->contlen, c->pkt->content);
     } else {
         DEBUGMSG_CFWD(DEBUG, "  content not added to cache\n");

--- a/src/ccnl-core.c
+++ b/src/ccnl-core.c
@@ -723,9 +723,9 @@ ccnl_content_add2cache(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
         }
     }
     if ((ccnl->max_cache_entries == 0) ||
-        (ccnl->contentcnt <= ccnl->max_cache_entries)) {
+        (ccnl->contentcnt < ccnl->max_cache_entries)) {
         DBL_LINKED_LIST_ADD(ccnl->contents, c);
-    ccnl->contentcnt++;
+        ccnl->contentcnt++;
     }
     else {
         DEBUGMSG_CORE(WARNING, " cache is full, cannot add new entry\n");


### PR DESCRIPTION
Changeset:
 * discard packets in forwarding if cache is already full (and nothing can be removed)
 * fix off-by-one error when adding to cache