### PR TITLE
RIOT adapter: change API for send interest function

### DIFF
--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -100,6 +100,11 @@ static kernel_pid_t _ccnl_event_loop_pid = KERNEL_PID_UNDEF;
 ccnl_producer_func _prod_func = NULL;
 
 /**
+ * currently configured suite
+ */
+static int _ccnl_suite = CCNL_SUITE_NDNTLV;
+
+/**
  * @}
  */
 
@@ -479,12 +484,9 @@ ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout)
 
 /* generates and send out an interest */
 struct ccnl_interest_s
-*ccnl_send_interest(int suite, char *name, unsigned int *chunknum,
-                    unsigned char *buf, size_t buf_len)
+*ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, size_t buf_len)
 {
-    struct ccnl_prefix_s *prefix;
-
-    if (suite != CCNL_SUITE_NDNTLV) {
+    if (_ccnl_suite != CCNL_SUITE_NDNTLV) {
         DEBUGMSG(WARNING, "Suite not supported by RIOT!");
         return NULL;
     }
@@ -492,16 +494,15 @@ struct ccnl_interest_s
     ccnl_mkInterestFunc mkInterest;
     ccnl_isContentFunc isContent;
 
-    mkInterest = ccnl_suite2mkInterestFunc(suite);
-    isContent = ccnl_suite2isContentFunc(suite);
+    mkInterest = ccnl_suite2mkInterestFunc(_ccnl_suite);
+    isContent = ccnl_suite2isContentFunc(_ccnl_suite);
 
     if (!mkInterest || !isContent) {
         DEBUGMSG(WARNING, "No functions for this suite were found!");
         return NULL;
     }
 
-    DEBUGMSG(INFO, "interest for chunk number: %u\n", (chunknum == NULL) ? 0 : *chunknum);
-    prefix = ccnl_URItoPrefix(name, suite, NULL, chunknum);
+    DEBUGMSG(INFO, "interest for chunk number: %u\n", (prefix->chunknum == NULL) ? 0 : *prefix->chunknum);
 
     if (!prefix) {
         DEBUGMSG(ERROR, "prefix could not be created!\n");
@@ -512,7 +513,6 @@ struct ccnl_interest_s
     DEBUGMSG(DEBUG, "nonce: %i\n", nonce);
 
     int len = mkInterest(prefix, &nonce, buf, buf_len);
-    free_prefix(prefix);
 
     unsigned char *start = buf;
     unsigned char *data = buf;

--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -478,15 +478,15 @@ ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout)
 /* TODO: move everything below here to ccn-lite-core-utils */
 
 /* generates and send out an interest */
-int
-ccnl_send_interest(int suite, char *name, unsigned int *chunknum,
+struct ccnl_interest_s
+*ccnl_send_interest(int suite, char *name, unsigned int *chunknum,
                     unsigned char *buf, size_t buf_len)
 {
     struct ccnl_prefix_s *prefix;
 
     if (suite != CCNL_SUITE_NDNTLV) {
         DEBUGMSG(WARNING, "Suite not supported by RIOT!");
-        return -1;
+        return NULL;
     }
 
     ccnl_mkInterestFunc mkInterest;
@@ -497,7 +497,7 @@ ccnl_send_interest(int suite, char *name, unsigned int *chunknum,
 
     if (!mkInterest || !isContent) {
         DEBUGMSG(WARNING, "No functions for this suite were found!");
-        return(-1);
+        return NULL;
     }
 
     DEBUGMSG(INFO, "interest for chunk number: %u\n", (chunknum == NULL) ? 0 : *chunknum);
@@ -505,7 +505,7 @@ ccnl_send_interest(int suite, char *name, unsigned int *chunknum,
 
     if (!prefix) {
         DEBUGMSG(ERROR, "prefix could not be created!\n");
-        return -1;
+        return NULL;
     }
 
     int nonce = random_uint32();
@@ -524,7 +524,7 @@ ccnl_send_interest(int suite, char *name, unsigned int *chunknum,
     /* TODO: support other suites */
     if (ccnl_ndntlv_dehead(&data, &len, (int*) &typ, &int_len) || (int) int_len > len) {
         DEBUGMSG(WARNING, "  invalid packet format\n");
-        return -1;
+        return NULL;
     }
     pkt = ccnl_ndntlv_bytes2pkt(NDN_TLV_Interest, start, &data, &len);
 
@@ -532,7 +532,7 @@ ccnl_send_interest(int suite, char *name, unsigned int *chunknum,
     ccnl_interest_append_pending(i, loopback_face);
     ccnl_interest_propagate(&ccnl_relay, i);
 
-    return 0;
+    return i;
 }
 
 void ccnl_set_local_producer(ccnl_producer_func func)


### PR DESCRIPTION
Two changes:
 * the function expects a `struct ccnl_prefix_s` pointer directly now instead of constructing it itself
 * it returns a pointer to the PIT entry