### PR TITLE
0 retransmissions mean no retransmissions

### DIFF
--- a/src/ccnl-core.c
+++ b/src/ccnl-core.c
@@ -867,7 +867,7 @@ ccnl_do_ageing(void *ptr, void *dummy)
     while (i) { // CONFORM: "Entries in the PIT MUST timeout rather
                 // than being held indefinitely."
         if ((i->last_used + CCNL_INTEREST_TIMEOUT) <= t ||
-                                i->retries > CCNL_MAX_INTEREST_RETRANSMIT) {
+                                i->retries >= CCNL_MAX_INTEREST_RETRANSMIT) {
             char *s = NULL;
             DEBUGMSG_CORE(TRACE, "AGING: INTEREST REMOVE %p\n", (void*) i);
             DEBUGMSG_CORE(DEBUG, " timeout: remove interest 0x%p <%s>\n",


### PR DESCRIPTION
Without this patch setting `CCNL_MAX_INTEREST_RETRANSMIT` to 0 will still result in up to one retransmit.