### PR TITLE
ndntlv: ppkl is currently never set

### DIFF
--- a/src/ccnl-core-util.c
+++ b/src/ccnl-core-util.c
@@ -837,7 +837,6 @@ free_packet(struct ccnl_pkt_s *pkt)
 #ifdef USE_SUITE_NDNTLV
             case CCNL_SUITE_NDNTLV:
                 ccnl_free(pkt->s.ndntlv.nonce);
-                ccnl_free(pkt->s.ndntlv.ppkl);
                 break;
 #endif
 #ifdef USE_SUITE_CISTLV

--- a/src/ccnl-core.c
+++ b/src/ccnl-core.c
@@ -621,9 +621,7 @@ ccnl_interest_isSame(struct ccnl_interest_s *i, struct ccnl_pkt_s *pkt)
 #ifdef USE_SUITE_NDNTLV
     case CCNL_SUITE_NDNTLV:
         return i->pkt->s.ndntlv.minsuffix == pkt->s.ndntlv.minsuffix &&
-               i->pkt->s.ndntlv.maxsuffix == pkt->s.ndntlv.maxsuffix &&
-               ((!i->pkt->s.ndntlv.ppkl && !pkt->s.ndntlv.ppkl) ||
-                    buf_equal(i->pkt->s.ndntlv.ppkl, pkt->s.ndntlv.ppkl));
+               i->pkt->s.ndntlv.maxsuffix == pkt->s.ndntlv.maxsuffix;
 #endif
 #ifdef USE_SUITE_CCNTLV
     case CCNL_SUITE_CCNTLV:

--- a/src/ccnl-core.h
+++ b/src/ccnl-core.h
@@ -255,7 +255,6 @@ struct ccnl_pktdetail_iottlv_s {
 struct ccnl_pktdetail_ndntlv_s {
     int minsuffix, maxsuffix, mbf, scope;
     struct ccnl_buf_s *nonce;      // nonce
-    struct ccnl_buf_s *ppkl;       // publisher public key locator
 };
 
 // packet flags:  0000ebtt

--- a/src/ccnl-headers.h
+++ b/src/ccnl-headers.h
@@ -318,7 +318,6 @@ int ccnl_ndntlv_prependInterest(struct ccnl_prefix_s *name, int scope, int *nonc
 /* ccnl-pkt-ndntlv.c */
 unsigned long int ccnl_ndntlv_nonNegInt(unsigned char *cp, int len);
 int ccnl_ndntlv_dehead(unsigned char **buf, int *len, int *typ, int *vallen);
-struct ccnl_buf_s *ccnl_ndntlv_extract(int hdrlen, unsigned char **data, int *datalen, int *scope, int *mbf, int *min, int *max, unsigned int *final_block_id, struct ccnl_prefix_s **prefix, struct ccnl_prefix_s **tracing, struct ccnl_buf_s **nonce, struct ccnl_buf_s **ppkl, unsigned char **content, int *contlen);
 int ccnl_ndntlv_prependTLval(unsigned long val, int *offset, unsigned char *buf);
 int ccnl_ndntlv_prependTL(int type, unsigned int len, int *offset, unsigned char *buf);
 int ccnl_ndntlv_prependNonNegInt(int type, unsigned int val, int *offset, unsigned char *buf);


### PR DESCRIPTION
Not so sure about the purpose of this struct member, but accessing a variable that is never set, seems potentially dangerous, hence I propose to remove it - unless we need it somehwere.
