### PR TITLE
introduce maximum number for PIT entries

### DIFF
--- a/src/ccn-lite-android.c
+++ b/src/ccn-lite-android.c
@@ -307,6 +307,7 @@ ccnl_relay_config(struct ccnl_relay_s *relay, int httpport, char *uxpath,
     DEBUGMSG(INFO, "configuring relay\n");
 
     relay->max_cache_entries = max_cache_entries;
+    relay->max_pit_entries = CCNL_DEFAULT_MAX_PIT_ENTRIES;
 #ifdef USE_SCHEDULER
     relay->defaultFaceScheduler = ccnl_relay_defaultFaceScheduler;
     relay->defaultInterfaceScheduler = ccnl_relay_defaultInterfaceScheduler;

--- a/src/ccn-lite-arduino.c
+++ b/src/ccn-lite-arduino.c
@@ -460,6 +460,7 @@ ccnl_arduino_init(struct ccnl_relay_s *relay, unsigned char *mac,
                   ccnl_addr2ascii(&theRelay.ifs[0].addr));
 
     relay->max_cache_entries = 0;
+    relay->max_pit_entries = CCNL_DEFAULT_MAX_PIT_ENTRIES;
     ccnl_set_timer(1000000, ccnl_ageing, relay, 0);
 
     sensor.suite = theSuite;

--- a/src/ccn-lite-lnxkernel.c
+++ b/src/ccn-lite-lnxkernel.c
@@ -566,6 +566,7 @@ ccnl_init(void)
 
     ccnl_core_init();
     theRelay.max_cache_entries = c;
+    theRelay.max_pit_entries = CCNL_DEFAULT_MAX_PIT_ENTRIES;
 #ifdef USE_SCHEDULER
     theRelay.defaultFaceScheduler = ccnl_lnx_defaultFaceScheduler;
 #endif

--- a/src/ccn-lite-relay.c
+++ b/src/ccn-lite-relay.c
@@ -430,6 +430,7 @@ ccnl_relay_config(struct ccnl_relay_s *relay, char *ethdev,
     DEBUGMSG(INFO, "configuring relay\n");
 
     relay->max_cache_entries = max_cache_entries;
+    relay->max_pit_entries = CCNL_DEFAULT_MAX_PIT_ENTRIES;
 #ifdef USE_SCHEDULER
     relay->defaultFaceScheduler = ccnl_relay_defaultFaceScheduler;
     relay->defaultInterfaceScheduler = ccnl_relay_defaultInterfaceScheduler;

--- a/src/ccn-lite-rfduino.c
+++ b/src/ccn-lite-rfduino.c
@@ -447,6 +447,7 @@ ccnl_rfduino_init(struct ccnl_relay_s *relay)
     ccnl_core_init();
 
     relay->max_cache_entries = 0;
+    relay->max_pit_entries = CCNL_DEFAULT_MAX_PIT_ENTRIES;
     ccnl_set_timer(1000000, ccnl_ageing, relay, 0);
 
     theRelay.ifcount = 1;

--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -427,6 +427,7 @@ ccnl_start(void)
     loopback_face->flags |= CCNL_FACE_FLAGS_STATIC;
 
     ccnl_relay.max_cache_entries = CCNL_CACHE_SIZE;
+    ccnl_relay.max_pit_entries = CCNL_DEFAULT_MAX_PIT_ENTRIES;
     /* start the CCN-Lite event-loop */
     _ccnl_event_loop_pid =  thread_create(_ccnl_stack, sizeof(_ccnl_stack),
                                           THREAD_PRIORITY_MAIN - 1,

--- a/src/ccn-lite-simu.c
+++ b/src/ccn-lite-simu.c
@@ -354,6 +354,7 @@ ccnl_simu_init_node(char node, const char *addr,
 
     relay->id = relay - relays;
     relay->max_cache_entries = node == 'C' ? -1 : max_cache_entries;
+    relay->max_pit_entries = CCNL_DEFAULT_MAX_PIT_ENTRIES;
 
     // add (fake) eth0 interface with index 0:
     i = &relay->ifs[0];

--- a/src/ccnl-core.c
+++ b/src/ccnl-core.c
@@ -395,6 +395,10 @@ struct ccnl_interest_s*
 ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
                   struct ccnl_pkt_s **pkt)
 {
+    if ((ccnl->pitcnt >= 0) &&
+        (ccnl->pitcnt >= ccnl->max_pit_entries)) {
+        return NULL;
+    }
     struct ccnl_interest_s *i = (struct ccnl_interest_s *) ccnl_calloc(1,
                                             sizeof(struct ccnl_interest_s));
     char *s = NULL;
@@ -412,6 +416,7 @@ ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
     i->from = from;
     i->last_used = CCNL_NOW();
     DBL_LINKED_LIST_ADD(ccnl->pit, i);
+    ccnl->pitcnt++;
 
     return i;
 }
@@ -597,6 +602,7 @@ ccnl_interest_remove(struct ccnl_relay_s *ccnl, struct ccnl_interest_s *i)
     }
     i2 = i->next;
     DBL_LINKED_LIST_REMOVE(ccnl->pit, i);
+    ccnl->pitcnt--;
 
     free_packet(i->pkt);
     ccnl_free(i);

--- a/src/ccnl-core.h
+++ b/src/ccnl-core.h
@@ -116,6 +116,8 @@ struct ccnl_relay_s {
     struct ccnl_buf_s *nonces;
     int contentcnt;             // number of cached items
     int max_cache_entries;      // -1: unlimited
+    int pitcnt;
+    int max_pit_entries;      // -1: unlimited
     struct ccnl_if_s ifs[CCNL_MAX_INTERFACES];
     int ifcount;                // number of active interfaces
     char halt_flag;

--- a/src/ccnl-defs.h
+++ b/src/ccnl-defs.h
@@ -42,18 +42,21 @@
 # define CCNL_MAX_PACKET_SIZE            120
 # define CCNL_MAX_ADDRESS_LEN            8
 # define CCNL_MAX_NAME_COMP              8
+# define CCNL_DEFAULT_MAX_PIT_ENTRIES    20
 #elif defined(CCNL_ANDROID) // max of BTLE and 2xUDP
 # define CCNL_MAX_INTERFACES             3
 # define CCNL_MAX_IF_QLEN                10
 # define CCNL_MAX_PACKET_SIZE            4096
 # define CCNL_MAX_ADDRESS_LEN            6
 # define CCNL_MAX_NAME_COMP              16
+# define CCNL_DEFAULT_MAX_PIT_ENTRIES    100
 #else
 # define CCNL_MAX_INTERFACES             10
 # define CCNL_MAX_IF_QLEN                64
 # define CCNL_MAX_PACKET_SIZE            8096
 # define CCNL_MAX_ADDRESS_LEN            6
 # define CCNL_MAX_NAME_COMP              64
+# define CCNL_DEFAULT_MAX_PIT_ENTRIES    (-1)
 #endif
 
 #define CCNL_CONTENT_TIMEOUT            300 // sec


### PR DESCRIPTION
On resource constrained systems this can help to avoid out of memory situations, since PIT entries are rather big.