### PR TITLE
RIOT adapter: some ageing and timer fixes

### DIFF
--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -433,6 +433,8 @@ ccnl_start(void)
     return _ccnl_event_loop_pid;
 }
 
+static xtimer_t _wait_timer = { .target = 0, .long_target = 0 };
+static msg_t _timeout_msg;
 int
 ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout)
 {
@@ -446,17 +448,10 @@ ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout)
         DEBUGMSG(DEBUG, "  waiting for packet\n");
 
         /* TODO: receive from socket or interface */
+        _timeout_msg.type = CCNL_MSG_TIMEOUT;
+        xtimer_set_msg64(&_wait_timer, timeout, &_timeout_msg, sched_active_pid);
         msg_t m;
-        if (xtimer_msg_receive_timeout(&m, timeout) >= 0) {
-            DEBUGMSG(DEBUG, "received something\n");
-        }
-        else {
-            /* TODO: handle timeout reasonably */
-            DEBUGMSG(WARNING, "timeout\n");
-            res = -ETIMEDOUT;
-            break;
-        }
-
+        msg_receive(&m);
         if (m.type == GNRC_NETAPI_MSG_TYPE_RCV) {
             DEBUGMSG(TRACE, "It's from the stack!\n");
             gnrc_pktsnip_t *pkt = (gnrc_pktsnip_t *)m.content.ptr;
@@ -474,6 +469,11 @@ ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout)
                 gnrc_pktbuf_release(pkt);
                 continue;
             }
+            xtimer_remove(&_wait_timer);
+            break;
+        }
+        else if (m.type == CCNL_MSG_TIMEOUT) {
+            res = -ETIMEDOUT;
             break;
         }
         else {

--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -413,7 +413,7 @@ void
                 break;
             case CCNL_MSG_AGEING:
                 DEBUGMSG(VERBOSE, "ccn-lite: ageing timer\n");
-                ccnl_ageing(arg, NULL);
+                ccnl_do_ageing(arg, NULL);
                 break;
             default:
                 DEBUGMSG(WARNING, "ccn-lite: unknown message type\n");

--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -390,10 +390,7 @@ void
     while(!ccnl->halt_flag) {
         msg_t m, reply;
         DEBUGMSG(VERBOSE, "ccn-lite: waiting for incoming message.\n");
-        int usec = ccnl_run_events();
-        if (xtimer_msg_receive_timeout(&m, usec) < 0) {
-            continue;
-        }
+        msg_receive(&m);
 
         switch (m.type) {
             case GNRC_NETAPI_MSG_TYPE_RCV:


### PR DESCRIPTION
This replaces the coarse ccn-lite timer with RIOT's native more fine-grained xtimer for ageing and timeouts. It also provides a bug fix to avoid multiple ageing timers to be scheduled in the RIOT adapter.