### PR TITLE
RIOT adapter: implement GNRC netapi send

### DIFF
--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -403,6 +403,15 @@ void
 
             case GNRC_NETAPI_MSG_TYPE_SND:
                 DEBUGMSG(DEBUG, "ccn-lite: GNRC_NETAPI_MSG_TYPE_SND received\n");
+                gnrc_pktsnip_t *pkt = (gnrc_pktsnip_t*) m.content.ptr;
+                if (pkt->type != GNRC_NETTYPE_CCN) {
+                    DEBUGMSG(WARNING, "ccn-lite: wrong nettype\n");
+                }
+                else {
+                    ccnl_interest_t *i = (ccnl_interest_t*) pkt->data;
+                    ccnl_send_interest(i->prefix, i->buf, i->buflen);
+                }
+                gnrc_pktbuf_release(pkt);
                 break;
 
             case GNRC_NETAPI_MSG_TYPE_GET:


### PR DESCRIPTION
Upper layers should use netapi instead of calling the TX function directly.