### PR TITLE
introduce hook for different cache strategy

### DIFF
--- a/src/ccn-lite-android.c
+++ b/src/ccn-lite-android.c
@@ -87,6 +87,7 @@ unsigned char keyid[32];
 
 #define ccnl_app_RX(x,y)                do{}while(0)
 #define local_producer(...)             0
+#define cache_strategy_remove(...)      0
 
 #include "ccnl-core.c"
 

--- a/src/ccn-lite-arduino.c
+++ b/src/ccn-lite-arduino.c
@@ -207,6 +207,7 @@ inet_ntoa(struct in_addr a)
 
 #define ccnl_app_RX(x,y)                do{}while(0)
 #define ccnl_print_stats(x,y)           do{}while(0)
+#define cache_strategy_remove(...)      0
 
 char* ccnl_addr2ascii(sockunion *su);
 

--- a/src/ccn-lite-lnxkernel.c
+++ b/src/ccn-lite-lnxkernel.c
@@ -56,6 +56,7 @@
 
 #define ccnl_app_RX(x,y)                do{}while(0)
 #define local_producer(...)             0
+#define cache_strategy_remove(...)      0
 
 static struct ccnl_relay_s theRelay;
 

--- a/src/ccn-lite-minimalrelay.c
+++ b/src/ccn-lite-minimalrelay.c
@@ -117,6 +117,7 @@ int inet_aton(const char *cp, struct in_addr *inp);
 
 #define compute_ccnx_digest(b) NULL
 #define local_producer(...)             0
+#define cache_strategy_remove(...)      0
 
 //----------------------------------------------------------------------
 

--- a/src/ccn-lite-relay.c
+++ b/src/ccn-lite-relay.c
@@ -69,6 +69,7 @@
 
 #define ccnl_app_RX(x,y)                do{}while(0)
 #define local_producer(...)             0
+#define cache_strategy_remove(...)      0
 
 #include "ccnl-core.c"
 

--- a/src/ccn-lite-rfduino.c
+++ b/src/ccn-lite-rfduino.c
@@ -203,6 +203,7 @@ char* ccnl_addr2ascii(sockunion *su);
 #define DEBUGMSG(...)      DEBUGMSG_OFF(__VA_VARGS__)
 
 #define local_producer(...) 0
+#define cache_strategy_remove(...)      0
 
 #include "ccnl-core.c"
 #include "ccnl-ext-frag.c"

--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -75,6 +75,12 @@ int local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
                    struct ccnl_pkt_s *pkt);
 
 /**
+/**
+ * @brief May be defined for a particular caching strategy
+ */
+int cache_strategy_remove(struct ccnl_relay_s *relay, struct ccnl_content_s *c);
+
+/**
  * @brief RIOT specific local variables
  * @{
  */
@@ -98,6 +104,11 @@ static kernel_pid_t _ccnl_event_loop_pid = KERNEL_PID_UNDEF;
  * local producer function defined by the application
  */
 ccnl_producer_func _prod_func = NULL;
+
+/**
+ * caching strategy removal function
+ */
+static ccnl_cache_strategy_func _cs_remove_func = NULL;
 
 /**
  * currently configured suite
@@ -553,11 +564,26 @@ void ccnl_set_local_producer(ccnl_producer_func func)
     _prod_func = func;
 }
 
+void
+ccnl_set_cache_strategy_remove(ccnl_cache_strategy_func func)
+{
+    _cs_remove_func = func;
+}
+
 int local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
                    struct ccnl_pkt_s *pkt)
 {
     if (_prod_func) {
         return _prod_func(relay, from, pkt);
+    }
+    return 0;
+}
+
+int
+cache_strategy_remove(struct ccnl_relay_s *relay, struct ccnl_content_s *c)
+{
+    if (_cs_remove_func) {
+        return _cs_remove_func(relay, c);
     }
     return 0;
 }

--- a/src/ccn-lite-simu.c
+++ b/src/ccn-lite-simu.c
@@ -53,6 +53,7 @@
 
 void ccnl_core_addToCleanup(struct ccnl_buf_s *buf);
 #define local_producer(...) 0
+#define cache_strategy_remove(...)      0
 
 #include "ccnl-ext-debug.c"
 #include "ccnl-os-time.c"

--- a/src/ccnl-core.c
+++ b/src/ccnl-core.c
@@ -714,19 +714,22 @@ ccnl_content_add2cache(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
 #endif
     if (ccnl->max_cache_entries > 0 &&
         ccnl->contentcnt >= ccnl->max_cache_entries) { // remove oldest content
-        struct ccnl_content_s *c2, *oldest = NULL;
-        int age = 0;
-        for (c2 = ccnl->contents; c2; c2 = c2->next) {
-            if (!(c2->flags & CCNL_CONTENT_FLAGS_STATIC)) {
-                if ((age == 0) || c2->last_used < age) {
-                    age = c2->last_used;
-                    oldest = c2;
+
+        if (!cache_strategy_remove(ccnl, c)) {
+            struct ccnl_content_s *c2, *oldest = NULL;
+            int age = 0;
+            for (c2 = ccnl->contents; c2; c2 = c2->next) {
+                if (!(c2->flags & CCNL_CONTENT_FLAGS_STATIC)) {
+                    if ((age == 0) || c2->last_used < age) {
+                        age = c2->last_used;
+                        oldest = c2;
+                    }
                 }
             }
-        }
-        if (oldest) {
-            DEBUGMSG_CORE(DEBUG, " remove old entry from cache\n");
-            ccnl_content_remove(ccnl, oldest);
+            if (oldest) {
+                DEBUGMSG_CORE(DEBUG, " remove old entry from cache\n");
+                ccnl_content_remove(ccnl, oldest);
+            }
         }
     }
     if ((ccnl->max_cache_entries < 0) ||

--- a/src/ccnl-uapi.h
+++ b/src/ccnl-uapi.h
@@ -593,6 +593,7 @@ static inline int           setMgmt (struct info_mgmt_s *m) {return m->vtable->s
 #include "ccnl-ext-debug.c"
 #include "ccnl-ext-logging.c"
 #define local_producer(...)             0
+#define cache_strategy_remove(...)      0
 
 /*
  * The following are aliases for legacy names that the ccn-lite code base uses,


### PR DESCRIPTION
This allows to define alternative cache replacement strategies from outside ccn-lite.