### PR TITLE
RIOT adapter: loopback traffic and TX timer reset

### DIFF
--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -292,6 +292,15 @@ ccnl_ll_TX(struct ccnl_relay_s *ccnl, struct ccnl_if_s *ifc,
                                     DEBUGMSG(ERROR, "error: unable to get address for if=<%u>\n", (unsigned) ifc->if_pid);
                                     return;
                                 }
+                                else if (res != addr_len) {
+                                    DEBUGMSG(DEBUG, " address length doesn't match, try long address\n");
+                                    res = gnrc_netapi_get(ifc->if_pid, NETOPT_ADDRESS_LONG, 0, hwaddr, sizeof(hwaddr));
+                                    if (res < 0) {
+                                        DEBUGMSG(ERROR, "error: unable to get address for if=<%u>\n", (unsigned) ifc->if_pid);
+                                        return;
+                                    }
+                                }
+
                                 if (memcmp(hwaddr, dest->linklayer.sll_addr, dest->linklayer.sll_halen) == 0) {
                                     DEBUGMSG(DEBUG, "loopback packet\n");
                                     /* build link layer header */

--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -108,7 +108,7 @@ static xtimer_t _ageing_timer = { .target = 0, .long_target = 0 };
 /**
  * local producer function defined by the application
  */
-ccnl_producer_func _prod_func = NULL;
+static ccnl_producer_func _prod_func = NULL;
 
 /**
  * caching strategy removal function
@@ -629,7 +629,8 @@ struct ccnl_interest_s
     return i;
 }
 
-void ccnl_set_local_producer(ccnl_producer_func func)
+void
+ccnl_set_local_producer(ccnl_producer_func func)
 {
     _prod_func = func;
 }
@@ -640,7 +641,8 @@ ccnl_set_cache_strategy_remove(ccnl_cache_strategy_func func)
     _cs_remove_func = func;
 }
 
-int local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
+int
+local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
                    struct ccnl_pkt_s *pkt)
 {
     if (_prod_func) {

--- a/src/ccnl-core.h
+++ b/src/ccnl-core.h
@@ -87,6 +87,8 @@ struct ccnl_if_s { // interface for packet IO
 #elif defined(CCNL_RIOT)
     kernel_pid_t if_pid;
     int sock;
+    uint8_t hwaddr[CCNL_MAX_ADDRESS_LEN];
+    uint16_t addr_len;
 #else
     int sock;
 #endif


### PR DESCRIPTION
This PR introduces the possibility to send loopback traffic through the RIOT adapter (useful to put locally produced data into the CS) and resets the TX timer after sending.