### PR TITLE
fwd: RONR: add FIB entry before caching

### DIFF
--- a/src/ccnl-core-fwd.c
+++ b/src/ccnl-core-fwd.c
@@ -79,6 +79,17 @@ ccnl_fwd_handleContent(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
         free_content(c);
         return 0;
     }
+#ifdef USE_RONR
+    /* if we receive a chunk, we assume more chunks of this content may be
+     * retrieved along the same path */
+    if ((c->pkt->pfx->chunknum) && (*(c->pkt->pfx->chunknum) >= 0)) {
+        struct ccnl_prefix_s *pfx_wo_chunk = ccnl_prefix_dup(c->pkt->pfx);
+        pfx_wo_chunk->compcnt--;
+        ccnl_free(pfx_wo_chunk->chunknum);
+        pfx_wo_chunk->chunknum = NULL;
+        ccnl_fib_add_entry(relay, pfx_wo_chunk, from);
+    }
+#endif
     if (relay->max_cache_entries != 0) { // it's set to -1 or a limit
         DEBUGMSG_CFWD(DEBUG, "  adding content to cache\n");
         if (ccnl_content_add2cache(relay, c) == NULL) {
@@ -91,17 +102,6 @@ ccnl_fwd_handleContent(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
         DEBUGMSG_CFWD(DEBUG, "  content not added to cache\n");
         free_content(c);
     }
-#ifdef USE_RONR
-    /* if we receive a chunk, we assume more chunks of this content may be
-     * retrieved along the same path */
-    if ((c->pkt->pfx->chunknum) && (*(c->pkt->pfx->chunknum) >= 0)) {
-        struct ccnl_prefix_s *pfx_wo_chunk = ccnl_prefix_dup(c->pkt->pfx);
-        pfx_wo_chunk->compcnt--;
-        ccnl_free(pfx_wo_chunk->chunknum);
-        pfx_wo_chunk->chunknum = NULL;
-        ccnl_fib_add_entry(relay, pfx_wo_chunk, from);
-    }
-#endif
     return 0;
 }
 


### PR DESCRIPTION
If caching fails (e.g., if no cache is configured), the FIB entry should be still added.