### PR TITLE
fix compiler warnings on macOS

### DIFF
--- a/src/ccnl-core-fwd.c
+++ b/src/ccnl-core-fwd.c
@@ -78,10 +78,10 @@ ccnl_fwd_handleContent(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     // Find the original prefix for the intermediate result and use that prefix to cache the content.
     if (ccnl_nfnprefix_isIntermediate((*pkt)->pfx)) {
         if (ccnl_nfn_RX_intermediate(relay, from, pkt)) {
-            // This was an intermediate result from the compute server. 
+            // This was an intermediate result from the compute server.
             // It was cached, and shouldn't be forwarded.
             DEBUGMSG_CFWD(VERBOSE, "received intermediate result from compute server \n");
-            return 0;   
+            return 0;
         }
     }
 #endif
@@ -123,7 +123,7 @@ ccnl_fwd_handleContent(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
         if (relay->max_cache_entries != 0) { // it's set to -1 or a limit
             DEBUGMSG_CFWD(DEBUG, "  adding content to cache\n");
             ccnl_content_add2cache(relay, c);
-    	    DEBUGMSG_CFWD(INFO, "data after creating packet %.*s\n", c->pkt->contlen, c->pkt->content);
+            DEBUGMSG_CFWD(INFO, "data after creating packet %.*s\n", c->pkt->contlen, c->pkt->content);
         } else {
             DEBUGMSG_CFWD(DEBUG, "  content not added to cache\n");
             free_content(c);
@@ -198,10 +198,10 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     struct ccnl_interest_s *i;
     struct ccnl_content_s *c;
 
-    int nonce = 0;
+    int32_t nonce = 0;
     if (pkt != NULL && (*pkt) != NULL && (*pkt)->s.ndntlv.nonce != NULL) {
         if ((*pkt)->s.ndntlv.nonce->datalen == 4) {
-            nonce = *((int*)(*pkt)->s.ndntlv.nonce->data);
+            memcpy(&nonce, (*pkt)->s.ndntlv.nonce->data, 4);
         }
     }
 
@@ -215,7 +215,7 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
 #ifdef USE_DUP_CHECK
     if (ccnl_nonce_isDup(relay, *pkt)) {
         DEBUGMSG_CFWD(DEBUG, "  dropped because of duplicate nonce %i\n", nonce);
-        
+
         return 0;
     }
 #endif
@@ -244,15 +244,15 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
             char reply[16];
             snprintf(reply, 16, "%d", internum);
             int size = internum >= 0 ? strlen(reply) : 0;
-            struct ccnl_buf_s *buf  = ccnl_mkSimpleContent((*pkt)->pfx, (unsigned char *)reply, size, &offset);        
-            ccnl_face_enqueue(relay, from, buf);    
+            struct ccnl_buf_s *buf  = ccnl_mkSimpleContent((*pkt)->pfx, (unsigned char *)reply, size, &offset);
+            ccnl_face_enqueue(relay, from, buf);
             return 0;
         } else {
             DEBUGMSG_CFWD(DEBUG, "  no running computation found.\n");
         }
     }
 #endif
-    
+
 
     // Step 1: search in content store
     DEBUGMSG_CFWD(DEBUG, "  searching in CS\n");


### PR DESCRIPTION
this PR fixes compiler warning on macOS. It make size of nounce explicitly being 4 bytes.

Minor nit: this PR also removes some trailing whitespaces.