### PR TITLE
ccn-lite-relay: missing include for debug message

### DIFF
--- a/src/ccn-lite-relay.c
+++ b/src/ccn-lite-relay.c
@@ -25,6 +25,7 @@
 #include <regex.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <inttypes.h>
 
 #define CCNL_UNIX
 


### PR DESCRIPTION
Fixes a bug that was introduced in #104.