### PR TITLE
ccn-lite-relay: provide initial support for linux-wpan (IEEE802.15.4)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -57,6 +57,10 @@ ifeq ($(uname_S),Linux)
         $(info *** With Linux Kernel ***)
         PROGS += ccn-lite-lnxkernel
     endif
+    ifdef USE_WPAN
+        $(info *** With WPAN support ***)
+        CCNLCFLAGS += -DUSE_WPAN
+    endif
 
     # Some investigation needed to compile ccn-lite-simu with OSX
     PROGS += ccn-lite-simu

--- a/src/ccnl-core-util.c
+++ b/src/ccnl-core-util.c
@@ -50,6 +50,9 @@ const char *compile_string = ""
 #ifdef USE_LINKLAYER
         "ETHERNET, "
 #endif
+#ifdef USE_WPAN
+        "WPAN, "
+#endif
 #ifdef USE_FRAG
         "FRAG, "
 #endif
@@ -941,6 +944,26 @@ ccnl_addr2ascii(sockunion *su)
         strcpy(result, ll2ascii(ll->sll_addr, ll->sll_halen));
         sprintf(result+strlen(result), "/0x%04x",
             ntohs(ll->sll_protocol));
+        return result;
+    }
+#endif
+#ifdef USE_WPAN
+    case AF_IEEE802154: {
+        struct sockaddr_ieee802154 *wpan = &su->wpan;
+        sprintf(result, "PANID:0x%04x", wpan->addr.pan_id);
+        switch (wpan->addr.addr_type) {
+            case IEEE802154_ADDR_NONE:
+                break;
+            case IEEE802154_ADDR_SHORT:
+                sprintf(result+strlen(result), ",0x%04x", wpan->addr.addr.short_addr);
+                break;
+            case IEEE802154_ADDR_LONG:
+                sprintf(result+strlen(result), ",%s", ll2ascii(wpan->addr.addr.hwaddr, IEEE802154_ADDR_LEN));
+                break;
+            default:
+                strcpy(result+strlen(result), ",UNKNOWN");
+                break;
+        }
         return result;
     }
 #endif

--- a/src/ccnl-core.h
+++ b/src/ccnl-core.h
@@ -42,7 +42,7 @@
 #define CCNL_FRAG_SEQUENCED2015 3
 #define CCNL_FRAG_BEGINEND2015  4
 
-#ifdef CCNL_RIOT
+#if defined(CCNL_RIOT) || defined(USE_WPAN)
 #define CCNL_LLADDR_STR_MAX_LEN    (3 * 8)
 #else
 /* unless a platform supports a link layer with longer addresses than Ethernet,
@@ -50,6 +50,31 @@
 #define CCNL_LLADDR_STR_MAX_LEN    (3 * 6)
 #endif
 // ----------------------------------------------------------------------
+
+#ifdef USE_WPAN
+/* TODO: remove when af_ieee802154.h is in linux mainline */
+#define IEEE802154_ADDR_LEN 8
+
+typedef enum {
+    IEEE802154_ADDR_NONE = 0x0,
+    IEEE802154_ADDR_SHORT = 0x2,
+    IEEE802154_ADDR_LONG = 0x3,
+} wpan_addr_type_t;
+
+struct ieee802154_addr_sa {
+    int addr_type;
+    uint16_t pan_id;
+    union {
+        uint8_t hwaddr[IEEE802154_ADDR_LEN];
+        uint16_t short_addr;
+    } addr;
+};
+
+struct sockaddr_ieee802154 {
+    sa_family_t family;
+    struct ieee802154_addr_sa addr;
+};
+#endif
 
 typedef union {
     struct sockaddr sa;
@@ -61,6 +86,9 @@ typedef union {
 #endif
 #ifdef USE_LINKLAYER
     struct sockaddr_ll linklayer;
+#endif
+#ifdef USE_WPAN
+    struct sockaddr_ieee802154 wpan;
 #endif
 #ifdef USE_UNIXSOCKET
     struct sockaddr_un ux;

--- a/src/ccnl-ext-debug.c
+++ b/src/ccnl-ext-debug.c
@@ -191,6 +191,10 @@ ccnl_dump(int lev, int typ, void *p)
             else if (fac->peer.sa.sa_family == AF_PACKET)
                 CONSOLE(" eth=%s", ccnl_addr2ascii(&fac->peer));
 #endif
+#ifdef USE_WPAN
+            else if (fac->peer.sa.sa_family == AF_IEEE802154)
+                CONSOLE(" wpan=%s", ccnl_addr2ascii(&fac->peer));
+#endif
 #ifdef USE_UNIXSOCKET
             else if (fac->peer.sa.sa_family == AF_UNIX)
                 CONSOLE(" ux=%s", ccnl_addr2ascii(&fac->peer));

--- a/src/ccnl-ext.h
+++ b/src/ccnl-ext.h
@@ -213,6 +213,9 @@ int ccnl_nfn_monitor(struct ccnl_relay_s *ccnl, struct ccnl_face_s *face,
 # ifdef USE_LINKLAYER
   int ccnl_open_ethdev(char *devname, struct sockaddr_ll *sll, int ethtype);
 # endif
+# ifdef USE_WPAN
+  int ccnl_open_wpandev(char *devname, struct sockaddr_ieee802154 *swpan);
+# endif
 
 #endif // !CCNL_LINUXKERNEL
 

--- a/src/ccnl-uapi.c
+++ b/src/ccnl-uapi.c
@@ -351,6 +351,11 @@ processSuiteData (void *relay, struct info_data_s *o, sockunion * from_addr /*0 
             addr_len = sizeof(from_addr->linklayer);
             break;
 #endif
+#ifdef USE_WPAN
+        case AF_IEEE802154:
+            addr_len = sizeof(from_addr->wpan);
+            break;
+#endif
 #ifdef USE_IPV4
         case AF_INET:
             addr_len = sizeof(from_addr->ip4);


### PR DESCRIPTION
An initial port to be able to run ICN over IEEE 802.15.4 on Linux. Tested with a modified raspbian as described in [this Wiki](https://github.com/RIOT-Makers/wpan-raspbian/wiki/Create-a-generic-Raspbian-image-with-6LoWPAN-support) against the RIOT port.