### PR TITLE
ccn-lite-riot.c: reuse ccnl_ndntlv_forwarder to send interests

### DIFF
--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -619,11 +619,9 @@ struct ccnl_interest_s
     }
     pkt = ccnl_ndntlv_bytes2pkt(NDN_TLV_Interest, start, &data, &len);
 
-    struct ccnl_interest_s *i = ccnl_interest_new(&ccnl_relay, loopback_face, &pkt);
-    if (i) {
-        ccnl_interest_append_pending(i, loopback_face);
-        ccnl_interest_propagate(&ccnl_relay, i);
-    }
+    ret = ccnl_fwd_handleInterest(&ccnl_relay, loopback_face, &pkt, ccnl_ndntlv_cMatch);
+
+    free_packet(pkt);
 
     return i;
 }

--- a/src/ccn-lite-riot.c
+++ b/src/ccn-lite-riot.c
@@ -574,12 +574,14 @@ ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout)
 /* TODO: move everything below here to ccn-lite-core-utils */
 
 /* generates and send out an interest */
-struct ccnl_interest_s
-*ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, size_t buf_len)
+int
+ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, size_t buf_len)
 {
+    int ret = -1;
+
     if (_ccnl_suite != CCNL_SUITE_NDNTLV) {
         DEBUGMSG(WARNING, "Suite not supported by RIOT!");
-        return NULL;
+        return ret;
     }
 
     ccnl_mkInterestFunc mkInterest;
@@ -590,14 +592,14 @@ struct ccnl_interest_s
 
     if (!mkInterest || !isContent) {
         DEBUGMSG(WARNING, "No functions for this suite were found!");
-        return NULL;
+        return ret;
     }
 
     DEBUGMSG(INFO, "interest for chunk number: %u\n", (prefix->chunknum == NULL) ? 0 : *prefix->chunknum);
 
     if (!prefix) {
         DEBUGMSG(ERROR, "prefix could not be created!\n");
-        return NULL;
+        return ret;
     }
 
     int nonce = random_uint32();
@@ -615,7 +617,7 @@ struct ccnl_interest_s
     /* TODO: support other suites */
     if (ccnl_ndntlv_dehead(&data, &len, (int*) &typ, &int_len) || (int) int_len > len) {
         DEBUGMSG(WARNING, "  invalid packet format\n");
-        return NULL;
+        return ret;
     }
     pkt = ccnl_ndntlv_bytes2pkt(NDN_TLV_Interest, start, &data, &len);
 
@@ -623,7 +625,7 @@ struct ccnl_interest_s
 
     free_packet(pkt);
 
-    return i;
+    return ret;
 }
 
 void


### PR DESCRIPTION
The current implementation does not honor the local cache when emitting
interests. By reusing the `ccnl_ndntlv_forwarder()` function, the local
cache is checked before propagating the interest.