### PR TITLE
ccnl-core: correct number of interest retransmits

### DIFF
--- a/src/ccnl-core.c
+++ b/src/ccnl-core.c
@@ -964,7 +964,7 @@ ccnl_do_ageing(void *ptr, void *dummy)
     while (i) { // CONFORM: "Entries in the PIT MUST timeout rather
                 // than being held indefinitely."
         if ((i->last_used + CCNL_INTEREST_TIMEOUT) <= t ||
-                                i->retries > CCNL_MAX_INTEREST_RETRANSMIT) {
+                                i->retries >= CCNL_MAX_INTEREST_RETRANSMIT) {
 #ifdef USE_TIMEOUT_KEEPALIVE
                 if (!(i->pkt->pfx->nfnflags & CCNL_PREFIX_NFN)) {
                     DEBUGMSG_AGEING("AGING: REMOVE CCN INTEREST", "timeout: remove interest");


### PR DESCRIPTION
Without this fix the maximum number of interest retransmissions is `CCNL_MAX_INTEREST_RETRANSMIT`+1