### PR TITLE
ccnl-core-util.c: fix ccnl_cs_dump memory leak

### DIFF
--- a/src/ccnl-core-util.c
+++ b/src/ccnl-core-util.c
@@ -1110,12 +1110,14 @@ ccnl_cs_dump(struct ccnl_relay_s *ccnl)
 {
     struct ccnl_content_s *c = ccnl->contents;
     unsigned i = 0;
+    char *s;
     while (c) {
         printf("CS[%u]: %s [%d]: %s\n", i++,
-               ccnl_prefix_to_path(c->pkt->pfx),
+               (s = ccnl_prefix_to_path(c->pkt->pfx)),
                (c->pkt->pfx->chunknum)? *(c->pkt->pfx->chunknum) : -1,
                c->pkt->content);
         c = c->next;
+        ccnl_free(s);
     }
 }
 


### PR DESCRIPTION
On most platforms, `ccnl_prefix_to_path` implies a malloc. I think in many places the allocated memory is not free'd after a call to `ccnl_prefix_to_path`. Nevertheless, this patch free's the memory explicitely in the `ccnl_cs_dump()` function.