### PR TITLE
ccnl-core-fwd.c: remove superfluous code for USE_KITE

### DIFF
--- a/src/ccnl-core-fwd.c
+++ b/src/ccnl-core-fwd.c
@@ -281,12 +281,6 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     }
 
     // CONFORM: Step 2: check whether interest is already known
-#ifdef USE_KITE
-    if ((*pkt)->tracing) { // is a tracing interest
-        for (i = relay->pit; i; i = i->next) {
-        }
-    }
-#endif
     for (i = relay->pit; i; i = i->next)
         if (ccnl_interest_isSame(i, *pkt))
             break;


### PR DESCRIPTION
I am wondering about the purpose of the code block that I removed in this patch. It shouldn't hurt to remove it, or am I mistaken? The sole purpose I see is that this code block advances `i`, but in the next loop a few lines below, `i` is again used as a loop variable and therefore overwritten.