### PR TITLE
ccnl-core: ccnl-fwd: fix -Werror=strict-prototypes

### DIFF
--- a/src/ccnl-core/src/ccnl-array.c
+++ b/src/ccnl-core/src/ccnl-array.c
@@ -20,7 +20,7 @@
  * 2017-06-16 created
  */
 
-void null_func();
+void null_func(void);
 
 #ifndef CCNL_LINUXKERNEL
 

--- a/src/ccnl-core/src/ccnl-http-status.c
+++ b/src/ccnl-core/src/ccnl-http-status.c
@@ -20,7 +20,7 @@
  * 2013-04-11 created
  */
 
-void null_func();
+void null_func(void);
 
 #ifdef USE_HTTP_STATUS
 

--- a/src/ccnl-fwd/src/ccnl-echo.c
+++ b/src/ccnl-fwd/src/ccnl-echo.c
@@ -20,7 +20,7 @@
  * 2015-01-12 created
  */
 
-void null_func();
+void null_func(void);
 
 #ifdef USE_ECHO
 


### PR DESCRIPTION
Building with `-Werror=strict-prototypes` – which is the case for RIOT – breaks without this patch.

```c
src/ccnl-echo.c:23:1: error: function declaration isn’t a prototype
[-Werror=strict-prototypes]
```