### PR TITLE
riot: macro cleanup

### DIFF
--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -49,27 +49,6 @@ extern "C" {
  * @}
  */
 
-
-
-/**
- * @brief Some macro definitions
- * @{
- */
-#define free_2ptr_list(a,b)     ccnl_free(a), ccnl_free(b)
-#define free_3ptr_list(a,b,c)   ccnl_free(a), ccnl_free(b), ccnl_free(c)
-#define free_4ptr_list(a,b,c,d) ccnl_free(a), ccnl_free(b), ccnl_free(c), ccnl_free(d);
-#define free_5ptr_list(a,b,c,d,e) ccnl_free(a), ccnl_free(b), ccnl_free(c), ccnl_free(d), ccnl_free(e);
-/**
- * @}
- */
-
-/**
- * Frees all memory directly and indirectly allocated for prefix information
- */
-#define free_prefix(p)  do{ if(p) \
-                free_5ptr_list(p->bytes,p->comp,p->complen,p->chunknum,p); } while(0)
-
-
 /**
  * Constant string
  */

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -48,32 +48,6 @@
 #endif
 
 /**
- * @brief Some macro definitions
- * @{
- */
-
-#define free_2ptr_list(a,b)     ccnl_free(a), ccnl_free(b)
-#define free_3ptr_list(a,b,c)   ccnl_free(a), ccnl_free(b), ccnl_free(c)
-#define free_4ptr_list(a,b,c,d) ccnl_free(a), ccnl_free(b), ccnl_free(c), ccnl_free(d);
-#define free_5ptr_list(a,b,c,d,e) ccnl_free(a), ccnl_free(b), ccnl_free(c), ccnl_free(d), ccnl_free(e);
-
-/**
- * Frees all memory directly and indirectly allocated for prefix information
- */
-#define free_prefix(p)  do{ if(p) \
-                free_5ptr_list(p->bytes,p->comp,p->complen,p->chunknum,p); } while(0)
-
-/**
- * Frees memory for a given content and the associated packet data
- */
-#define free_content(c) do{ /* free_prefix(c->name); */ ccnl_pkt_free(c->pkt); \
-                        ccnl_free(c); } while(0)
-
-/**
- * @}
- */
-
-/**
  * @brief May be defined for ad-hoc content creation
  */
 int local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,


### PR DESCRIPTION
Remove unused macros for the RIOT adapter. Most of them have been replaced with functions provided by the ccn-lite core.