### PR TITLE
ccnl-riot: port to new network interface API

### DIFF
--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -203,7 +203,7 @@ int
 ccnl_open_netif(kernel_pid_t if_pid, gnrc_nettype_t netreg_type)
 {
     assert(pid_is_valid(if_pid));
-    if (!gnrc_netif_exist(if_pid)) {
+    if (gnrc_netif_get_by_pid(if_pid) != NULL) {
         return -1;
     }
     if (ccnl_relay.ifcount >= CCNL_MAX_INTERFACES) {


### PR DESCRIPTION
With RIOT-OS/RIOT#7925, RIOT's network interface API was changed. This switches CCN-lite over to that new API.