### PR TITLE
ccnl-pkt: allocate memory for i->pkt before usage

### DIFF
--- a/src/ccnl-pkt/src/ccnl-pkt-builder.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-builder.c
@@ -229,6 +229,7 @@ ccnl_mkInterestObject(struct ccnl_prefix_s *name, int *nonce)
 {
     struct ccnl_interest_s *i = (struct ccnl_interest_s *) ccnl_calloc(1,
                                                                        sizeof(struct ccnl_interest_s));
+    i->pkt = (struct ccnl_pkt_s *) ccnl_calloc(1, sizeof(struct ccnl_pkt_s));
     i->pkt->buf = ccnl_mkSimpleInterest(name, nonce);
     i->pkt->pfx = ccnl_prefix_dup(name);
     i->flags |= CCNL_PIT_COREPROPAGATES;


### PR DESCRIPTION
`i->pkt` is `NULL`. This fix allocates memory for `i->pkt` before it is used.