### PR TITLE
removed static vars from ccnl_unix.h header

### DIFF
--- a/src/ccnl-core/src/ccnl-mgmt.c
+++ b/src/ccnl-core/src/ccnl-mgmt.c
@@ -2131,9 +2131,6 @@ ccnl_mgmt(struct ccnl_relay_s *ccnl, struct ccnl_buf_s *orig,
 
     MGMT:
     ccnl_mgmt_handle(ccnl, orig, prefix, from, cmd, 1);
-    (void) lasthour; 
-    (void) inter_ccn_interval;
-    (void) inter_pkt_interval;
     return 0;
 }
 

--- a/src/ccnl-relay/ccn-lite-relay.c
+++ b/src/ccnl-relay/ccn-lite-relay.c
@@ -73,6 +73,10 @@
 #include "ccn-lite-relay.h"
 #include "ccnl-unix.h"
 
+static int lasthour = -1;
+static int inter_ccn_interval = 0; // in usec
+static int inter_pkt_interval = 0; // in usec
+
 #ifdef CCNL_ARDUINO
 const char compile_string[] PROGMEM = ""
 #else

--- a/src/ccnl-unix/include/ccnl-unix.h
+++ b/src/ccnl-unix/include/ccnl-unix.h
@@ -42,10 +42,6 @@ int
 local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
                    struct ccnl_pkt_s *pkt);
 
-static int lasthour = -1;
-static int inter_ccn_interval = 0; // in usec
-static int inter_pkt_interval = 0; // in usec
-
 #ifdef USE_LINKLAYER
 #if !(defined(__FreeBSD__) || defined(__APPLE__))
 int

--- a/src/ccnl-unix/src/ccnl-unix.c
+++ b/src/ccnl-unix/src/ccnl-unix.c
@@ -36,6 +36,14 @@
 
 #include "ccnl-nfn.h"
 
+/**
+ * TODO: The variables are never updated within the context of
+ * ccnl_unix.c
+ */
+static int lasthour = -1;
+static int inter_ccn_interval = 0; // in usec
+static int inter_pkt_interval = 0; // in usec
+
 #ifdef USE_LINKLAYER
 int
 ccnl_open_ethdev(char *devname, struct sockaddr_ll *sll, int ethtype)


### PR DESCRIPTION
This PR removes the ``lasthour``, ``inter_ccn_interval``, and ``inter_pkt_interval `` static variables from the ``ccnl_unix.h`` header and adds local (private) static definitions where necessary. Most of these local definitions have already been in place. The issue has been discussed quite extensively in #151 

The variables ``inter_ccn_interval`` and ``inter_pkt_interval ``are never updated within scope of the `ccnl_unix.c`` source. I'm not really familiar with the codebase, but someone should probably check if that is really desired behaviour. 

If somebody would provide a quick explanation of the variables, I'm happy to add some documentation.