### PR TITLE
openssl: fix includes for non-standard location

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ set(CCNL_BASIC_FLAGS
 add_definitions(${CCNL_BASIC_FLAGS})
 
 if (NOT DEFINED CCNL_RIOT)
-   set(CCNL_EXTRA_FLAGS 
+   set(CCNL_EXTRA_FLAGS
         -DUSE_CCNxDIGEST
         -DUSE_MGMT
         -DUSE_UNIXSOCKET
@@ -88,6 +88,13 @@ else()
 endif()
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -g")
+
+if (NOT DEFINED CCNL_LINUXKERNEL AND NOT DEFINED CCNL_RIOT)
+    find_package(OpenSSL REQUIRED)
+    include_directories(${OPENSSL_INCLUDE_DIR})
+    message("OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
+    message("OpenSSL libraries: ${OPENSSL_LIBRARIES}")
+endif()
 
 #add_subdirectory(ccnl-addons)
 #if (DEFINED CCNL_RIOT)

--- a/src/ccnl-utils/CMakeLists.txt
+++ b/src/ccnl-utils/CMakeLists.txt
@@ -16,11 +16,7 @@ include_directories(
     ../ccnl-unix/include
     ../ccnl-nfn/include
     ../ccnl-pkt-compression/include
-    ${OPENSSL_INCLUDE_DIR}
-    
 )
-
-find_package(OpenSSL REQUIRED)
 
 add_executable(ccn-lite-peek ccn-lite-peek.c)
 #add_executable(ccn-lite-peekcomputation ccn-lite-peekcomputation.c) #todo work to do
@@ -56,7 +52,7 @@ if(OpenSSL_FOUND)
 
     target_link_libraries(ccn-lite-cryptoserver ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS} ${OPENSSL_LIBRARIES})
     target_link_libraries(ccn-lite-cryptoserver ccnl-core ccnl-pkt ccnl-fwd ccnl-unix ccnl-nfn ccnl-pkt-compression ${OPENSSL_LIBRARIES})
-    
+
     #target_link_libraries(ccn-lite-deF ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS} ${OPENSSL_LIBRARIES})
     #target_link_libraries(ccn-lite-deF ccnl-core ccnl-pkt ccnl-fwd ccnl-unix ccnl-nfn ${OPENSSL_LIBRARIES})
 
@@ -79,8 +75,8 @@ if(USE_FRAG)
     target_link_libraries(ccn-lite-mkF ccnl-core ccnl-pkt ccnl-fwd ccnl-unix ccnl-nfn ccnl-pkt-compression)
 endif()
 
-target_link_libraries(ccn-lite-mkI ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS}) 
-target_link_libraries(ccn-lite-mkI ccnl-core ccnl-pkt ccnl-fwd ccnl-unix ccnl-nfn ccnl-pkt-compression) 
+target_link_libraries(ccn-lite-mkI ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS})
+target_link_libraries(ccn-lite-mkI ccnl-core ccnl-pkt ccnl-fwd ccnl-unix ccnl-nfn ccnl-pkt-compression)
 
 target_link_libraries(ccn-lite-pktdump ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS})
 target_link_libraries(ccn-lite-pktdump ccnl-core ccnl-pkt ccnl-fwd ccnl-unix ccnl-nfn ccnl-pkt-compression)
@@ -90,7 +86,3 @@ target_link_libraries(ccn-lite-produce ccnl-core ccnl-pkt ccnl-fwd ccnl-unix ccn
 
 target_link_libraries(ccn-lite-simplenfn ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS})
 target_link_libraries(ccn-lite-simplenfn ccnl-core ccnl-pkt ccnl-fwd ccnl-unix ccnl-nfn ccnl-pkt-compression)
-
-
-
-


### PR DESCRIPTION
fixes #150 

tested on macOS, resolved issue as reported above.

However, the conditions when OpenSSL is required are somewhat ugly, but should match the requirements of CCNL as it is currently used. Still this should be tested on different platforms before merge. I'll check with RIOT and report.