### PR TITLE
single declaration and definition of function local_producer

### DIFF
--- a/src/ccnl-android/native/src/ccn-lite-android.c
+++ b/src/ccnl-android/native/src/ccn-lite-android.c
@@ -52,7 +52,6 @@ unsigned char keyid[32];
 #endif
 
 #define ccnl_app_RX(x,y)                do{}while(0)
-#define local_producer(...)             0
 #define cache_strategy_remove(...)      0
 
 

--- a/src/ccnl-core/include/ccnl-producer.h
+++ b/src/ccnl-core/include/ccnl-producer.h
@@ -18,7 +18,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
  * File history:
- * 2018-01-23 created
+ * 2018-01-23 created (based on ccn-lite-riot.h)
  */
 #ifndef CCNL_PRODUCER_H
 #define CCNL_PRODUCER_H
@@ -43,11 +43,17 @@ typedef int (*ccnl_producer_func)(struct ccnl_relay_s *relay,
 void ccnl_set_local_producer(ccnl_producer_func func);
 
 /**
- * @brief May be defined for ad-hoc content creation
+ * @brief Allows to generates content on the fly/or react to any kind of interest
  *
- * @param[in] relay
- * @param[in] from
- * @param[in] pkt
+ * A developer has to provide its own local_producer function which is set via 
+ * \ref ccnl_set_local_producer as a function pointer. If the function pointer 
+ * is not, set the function simply returns '0'. 
+ *
+ * @param[in] relay The active ccn-lite relay
+ * @param[in] from  The face the packet was received over
+ * @param[in] pkt   The actual received packet 
+ *
+ * @return 0 if no function has been set
  */
 #ifndef CCNL_ANDROID
 int local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,

--- a/src/ccnl-core/include/ccnl-producer.h
+++ b/src/ccnl-core/include/ccnl-producer.h
@@ -1,0 +1,61 @@
+/*
+ * @f ccnl-producer.h
+ * @b CCN lite, core CCNx protocol logic
+ *
+ * Copyright (C) 2011-18 University of Basel
+ * Copyright (C) 2015, 2016 INRIA
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * File history:
+ * 2018-01-23 created
+ */
+#ifndef CCNL_PRODUCER_H
+#define CCNL_PRODUCER_H
+
+#include "ccnl-core.h"
+
+/**
+ * @brief Function pointer type for local producer function
+ */
+typedef int (*ccnl_producer_func)(struct ccnl_relay_s *relay,
+                                  struct ccnl_face_s *from,
+                                  struct ccnl_pkt_s *pkt);
+
+/**
+ * @brief Set a local producer function
+ *
+ * Setting a local producer function allows to generate content on the fly or
+ * react otherwise on any kind of incoming interest.
+ *
+ * @param[in] func  The function to be called first for any incoming interest
+ */
+void ccnl_set_local_producer(ccnl_producer_func func);
+
+/**
+ * @brief May be defined for ad-hoc content creation
+ *
+ * @param[in] relay
+ * @param[in] from
+ * @param[in] pkt
+ */
+#ifndef CCNL_ANDROID
+int local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
+                   struct ccnl_pkt_s *pkt);
+#else
+#define local_producer(...) 0
+#endif
+
+
+#endif 
+

--- a/src/ccnl-core/src/ccnl-producer.c
+++ b/src/ccnl-core/src/ccnl-producer.c
@@ -1,0 +1,47 @@
+/*
+ * @f ccnl-producer.c
+ * @b Producer functions
+ *
+ * Copyright (C) 2011-14, Christian Tschudin, University of Basel
+ * Copyright (C) 2015, 2016, 2018, Oliver Hahm, INRIA
+ * Copyright (C) 2018, Michael Frey, MSA Safety
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * File history:
+ * 2018-01-24 created (based on ccn-lite-riot.c)
+ */
+
+#include "ccnl-producer.h"
+
+/**
+ * local producer function defined by the application
+ */
+static ccnl_producer_func _prod_func = NULL;
+
+void
+ccnl_set_local_producer(ccnl_producer_func func)
+{
+    _prod_func = func;
+}
+
+int
+local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
+                   struct ccnl_pkt_s *pkt)
+{
+    if (_prod_func) {
+        return _prod_func(relay, from, pkt);
+    }
+
+    return 0;
+}

--- a/src/ccnl-fwd/src/ccnl-fwd.c
+++ b/src/ccnl-fwd/src/ccnl-fwd.c
@@ -24,6 +24,7 @@
 #include "ccnl-fwd.h"
 
 #include "ccnl-core.h"
+#include "ccnl-producer.h"
 
 #include "ccnl-pkt-util.h"
 #ifdef USE_NFN
@@ -221,14 +222,6 @@ ccnl_pkt_fwdOK(struct ccnl_pkt_s *pkt)
 
     return -1;
 }
-
-#ifndef CCNL_ANDROID
-int
-local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
-                   struct ccnl_pkt_s *pkt);
-#else
-#define local_producer(...) 0
-#endif
 
 int
 ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,

--- a/src/ccnl-lnxkernel/ccn-lite-lnxkernel.c
+++ b/src/ccnl-lnxkernel/ccn-lite-lnxkernel.c
@@ -90,6 +90,7 @@
 #include <ccnl-logging.h>
 #include <ccnl-dispatch.h>
 #include <ccnl-malloc.h>
+#include <ccnl-producer.h>
 #include <ccnl-pkt-switch.h>
 
 #include "../../ccnl-pkt/src/ccnl-pkt-switch.c"
@@ -129,7 +130,6 @@
 #define assert(p) do{if(!p){DEBUGMSG(FATAL,"assertion violated %s:%d\n",__FILE__,__LINE__);}}while(0)
 
 #define ccnl_app_RX(x,y)                do{}while(0)
-//#define local_producer(...)             0
 
 #define cache_strategy_remove(...)      0
 
@@ -141,12 +141,6 @@ static int ccnl_eth_RX(struct sk_buff *skb, struct net_device *indev,
                       struct packet_type *pt, struct net_device *outdev);
 
 void ccnl_udp_data_ready(struct sock *sk);
-
-int
-local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
-               struct ccnl_pkt_s *pkt){
-    return 0;
-}
 
 // ----------------------------------------------------------------------
 

--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -105,13 +105,6 @@ typedef struct {
 extern struct ccnl_relay_s ccnl_relay;
 
 /**
- * @brief Function pointer type for local producer function
- */
-typedef int (*ccnl_producer_func)(struct ccnl_relay_s *relay,
-                                  struct ccnl_face_s *from,
-                                  struct ccnl_pkt_s *pkt);
-
-/**
  * @brief Function pointer type for caching strategy function
  */
 typedef int (*ccnl_cache_strategy_func)(struct ccnl_relay_s *relay,
@@ -166,16 +159,6 @@ int ccnl_send_interest(struct ccnl_prefix_s *prefix,
  * @return -ETIMEDOUT if no chunk was received until timeout
  */
 int ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout);
-
-/**
- * @brief Set a local producer function
- *
- * Setting a local producer function allows to generate content on the fly or
- * react otherwise on any kind of incoming interest.
- *
- * @param[in] func  The function to be called first for any incoming interest
- */
-void ccnl_set_local_producer(ccnl_producer_func func);
 
 /**
  * @brief Set a function to control the caching strategy

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -42,16 +42,11 @@
 
 #include "ccnl-os-time.h"
 #include "ccnl-fwd.h"
+#include "ccnl-producer.h"
 
 #ifdef USE_SUITE_COMPRESSED
 #include "ccnl-pkt-ndn-compression.h"
 #endif
-
-/**
- * @brief May be defined for ad-hoc content creation
- */
-int local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
-                   struct ccnl_pkt_s *pkt);
 
 /**
  * @brief May be defined for a particular caching strategy
@@ -83,10 +78,6 @@ static kernel_pid_t _ccnl_event_loop_pid = KERNEL_PID_UNDEF;
  */
 static xtimer_t _ageing_timer = { .target = 0, .long_target = 0 };
 
-/**
- * local producer function defined by the application
- */
-static ccnl_producer_func _prod_func = NULL;
 
 /**
  * caching strategy removal function
@@ -619,25 +610,9 @@ ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, size_t buf_
 }
 
 void
-ccnl_set_local_producer(ccnl_producer_func func)
-{
-    _prod_func = func;
-}
-
-void
 ccnl_set_cache_strategy_remove(ccnl_cache_strategy_func func)
 {
     _cs_remove_func = func;
-}
-
-int
-local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
-                   struct ccnl_pkt_s *pkt)
-{
-    if (_prod_func) {
-        return _prod_func(relay, from, pkt);
-    }
-    return 0;
 }
 
 int

--- a/src/ccnl-unix/include/ccnl-unix.h
+++ b/src/ccnl-unix/include/ccnl-unix.h
@@ -37,11 +37,6 @@
 #include "ccnl-if.h"
 #include "ccnl-buf.h"
 
-
-int
-local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
-                   struct ccnl_pkt_s *pkt);
-
 #ifdef USE_LINKLAYER
 #if !(defined(__FreeBSD__) || defined(__APPLE__))
 int

--- a/src/ccnl-unix/src/ccnl-unix.c
+++ b/src/ccnl-unix/src/ccnl-unix.c
@@ -25,6 +25,7 @@
 #include "ccnl-os-includes.h"
 
 #include "ccnl-core.h"
+#include "ccnl-producer.h"
 
 #include "ccnl-pkt-ccnb.h"
 #include "ccnl-pkt-ccntlv.h"
@@ -41,8 +42,10 @@
  * ccnl_unix.c
  */
 static int lasthour = -1;
+#ifdef USE_SCHEDULER
 static int inter_ccn_interval = 0; // in usec
 static int inter_pkt_interval = 0; // in usec
+#endif 
 
 #ifdef USE_LINKLAYER
 int
@@ -821,15 +824,3 @@ notacontent:
     closedir(dir);
 }
 
-int
-local_producer(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
-                   struct ccnl_pkt_s *pkt){
-                       //for unix not implemented yet
-    (void)relay;
-    (void)from;
-    (void)pkt;
-    (void)lasthour;
-    (void)inter_ccn_interval;
-    (void)inter_pkt_interval;
-    return 0;
-}


### PR DESCRIPTION
This PR provides a single declaration and definition of the function ``local_producer`` and addresses #148. It uses the implementation previously declared/defined in ``ccn-lite-riot.{h,c}``. 

None of the declared functions have documented return types. As far as I can see '0' seems to be the only common return type when the function pointer is not set/or the function was not implemented. 

If there are any remarks about the return types/documentation I'm happy to fix it.   🎉