### PR TITLE
ndntlv: remove keylocator for DIGESTSHA256

### DIFF
--- a/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
@@ -567,9 +567,11 @@ ccnl_ndntlv_prependContent(struct ccnl_prefix_s *name,
     // to find length of SignatureInfo
     oldoffset2 = *offset;
 
-    // optional (empty for now) because ndn client lib also puts it in by default
-    if (ccnl_ndntlv_prependTL(NDN_TLV_KeyLocator, 0, offset, buf) < 0)
-        return -1;
+    // KeyLocator is not required for DIGESTSHA256
+    if (signatureType != NDN_VAL_SIGTYPE_DIGESTSHA256) {
+        if (ccnl_ndntlv_prependTL(NDN_TLV_KeyLocator, 0, offset, buf) < 0)
+            return -1;
+    }
 
     // use NDN_SigTypeVal_SignatureSha256WithRsa because this is default in ndn client libs
     if (ccnl_ndntlv_prependBlob(NDN_TLV_SignatureType, &signatureType, 1,


### PR DESCRIPTION
The KeyLocator TLV is not required for DIGESTSHA256 and must be ignored if present [[1]](https://named-data.net/doc/ndn-tlv/signature.html#digestsha256).

Not including this saves some bytes over the air, which is especially beneficial for 802.15.4 networks.

>If KeyLocator is present in SignatureInfo, it must be ignored.