### PR TITLE
ccnl-core: fix old style definition for test

### DIFF
--- a/src/ccnl-core/test/ccnl_core_unit_test.c
+++ b/src/ccnl-core/test/ccnl_core_unit_test.c
@@ -1,5 +1,5 @@
 #include "ccnl-unit.h"
 
-int main(){
+int main(void){
     return 0;
 }


### PR DESCRIPTION
When building ccn-lite for RIOT, I get the following (due to `-Werror=old-style-definition`):

```
test/ccnl_core_unit_test.c:3:5: error: function declaration isn’t a prototype [-Werror=strict-prototypes]
 int main(){
     ^~~~
test/ccnl_core_unit_test.c: In function ‘main’:
test/ccnl_core_unit_test.c:3:5: error: old-style function definition [-Werror=old-style-definition]
cc1: all warnings being treated as errors

```