### PR TITLE
ccnl-pkt: static memory vs dynamic memory

### DIFF
--- a/src/ccnl-pkt/include/ccnl-pkt-builder.h
+++ b/src/ccnl-pkt/include/ccnl-pkt-builder.h
@@ -72,8 +72,23 @@ ccnl_mkContentObject(struct ccnl_prefix_s *name,
                      unsigned char *payload, int paylen);
 
 struct ccnl_buf_s*
+ccnl_mkSimpleContent_scratch(unsigned char *scratch, int scratch_len,
+                             struct ccnl_prefix_s *name,
+                             unsigned char *payload, int paylen, int *payoffset);
+
+static inline struct ccnl_buf_s*
 ccnl_mkSimpleContent(struct ccnl_prefix_s *name,
-                     unsigned char *payload, int paylen, int *payoffset);
+                     unsigned char *payload, int paylen, int *payoffset)
+{
+    struct ccnl_buf_s *buf = NULL;
+
+    unsigned char *tmp = (unsigned char*) ccnl_malloc(CCNL_MAX_PACKET_SIZE);
+    buf = ccnl_mkSimpleContent_scratch(tmp, CCNL_MAX_PACKET_SIZE, name,
+                                       payload, paylen, payoffset);
+    ccnl_free(tmp);
+
+    return buf;
+}
 
 void
 ccnl_mkContent(struct ccnl_prefix_s *name, unsigned char *payload, int paylen, unsigned char *tmp,
@@ -84,7 +99,20 @@ struct ccnl_interest_s *
 ccnl_mkInterestObject(struct ccnl_prefix_s *name, int *nonce);
 
 struct ccnl_buf_s*
-ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, int *nonce);
+ccnl_mkSimpleInterest_scratch(unsigned char *scratch, int scratch_len,
+                              struct ccnl_prefix_s *name, int *nonce);
+
+static inline struct ccnl_buf_s*
+ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, int *nonce)
+{
+    struct ccnl_buf_s *buf = NULL;
+
+    unsigned char *tmp = (unsigned char*) ccnl_malloc(CCNL_MAX_PACKET_SIZE);
+    buf = ccnl_mkSimpleInterest_scratch(tmp, CCNL_MAX_PACKET_SIZE, name, nonce);
+    ccnl_free(tmp);
+
+    return buf;
+}
 
 void
 ccnl_mkInterest(struct ccnl_prefix_s *name, int *nonce, unsigned char *tmp,

--- a/src/ccnl-pkt/src/ccnl-pkt-builder.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-builder.c
@@ -238,22 +238,18 @@ ccnl_mkInterestObject(struct ccnl_prefix_s *name, int *nonce)
 }
 
 struct ccnl_buf_s*
-ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, int *nonce)
+ccnl_mkSimpleInterest_scratch(unsigned char *scratch, int scratch_len,
+                              struct ccnl_prefix_s *name, int *nonce)
 {
     struct ccnl_buf_s *buf = NULL;
-    unsigned char *tmp;
-    int len = 0, offs;
+    int len = 0, offs = scratch_len;
     struct ccnl_prefix_s *prefix;
     (void)prefix;
 
-    tmp = (unsigned char*) ccnl_malloc(CCNL_MAX_PACKET_SIZE);
-    offs = CCNL_MAX_PACKET_SIZE;
-
-    ccnl_mkInterest(name, nonce, tmp, &len, &offs);
+    ccnl_mkInterest(name, nonce, scratch, &len, &offs);
 
     if (len > 0)
-        buf = ccnl_buf_new(tmp + offs, len);
-    ccnl_free(tmp);
+        buf = ccnl_buf_new(scratch + offs, len);
 
     return buf;
 }
@@ -326,12 +322,12 @@ ccnl_mkContentObject(struct ccnl_prefix_s *name,
 }
 
 struct ccnl_buf_s*
-ccnl_mkSimpleContent(struct ccnl_prefix_s *name,
-                     unsigned char *payload, int paylen, int *payoffset)
+ccnl_mkSimpleContent_scratch(unsigned char *scratch, int scratch_len,
+                             struct ccnl_prefix_s *name,
+                             unsigned char *payload, int paylen, int *payoffset)
 {
     struct ccnl_buf_s *buf = NULL;
-    unsigned char *tmp;
-    int len = 0, contentpos = 0, offs;
+    int len = 0, contentpos = 0, offs = scratch_len;
     struct ccnl_prefix_s *prefix;
     (void)prefix;
 
@@ -340,17 +336,13 @@ ccnl_mkSimpleContent(struct ccnl_prefix_s *name,
                   (s = ccnl_prefix_to_path(name)), paylen);
     ccnl_free(s);
 
-    tmp = (unsigned char*) ccnl_malloc(CCNL_MAX_PACKET_SIZE);
-    offs = CCNL_MAX_PACKET_SIZE;
-
-    ccnl_mkContent(name, payload, paylen, tmp, &len, &contentpos, &offs);
+    ccnl_mkContent(name, payload, paylen, scratch, &len, &contentpos, &offs);
 
     if (len) {
-        buf = ccnl_buf_new(tmp + offs, len);
+        buf = ccnl_buf_new(scratch + offs, len);
         if (payoffset)
             *payoffset = contentpos;
     }
-    ccnl_free(tmp);
 
     return buf;
 }

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -43,6 +43,7 @@
 #include "ccnl-os-time.h"
 #include "ccnl-fwd.h"
 #include "ccnl-producer.h"
+#include "ccnl-pkt-builder.h"
 
 #ifdef USE_SUITE_COMPRESSED
 #include "ccnl-pkt-ndn-compression.h"
@@ -167,7 +168,6 @@ static gnrc_netreg_entry_t _ccnl_ne;
  * @{
  */
 
-extern struct ccnl_buf_s* ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, int *nonce);
 extern int ccnl_isContent(unsigned char *buf, int len, int suite);
 
 /**
@@ -550,11 +550,6 @@ ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, size_t buf_
     int ret = -1;
     int len = 0;
 
-    /* we are not using these _for now_. Need to adjust ccnl_mkSimpleInterest
-       to work with static buffers first */
-    (void) buf;
-    (void) buf_len;
-
     if (_ccnl_suite != CCNL_SUITE_NDNTLV) {
         DEBUGMSG(WARNING, "Suite not supported by RIOT!");
         return ret;
@@ -570,7 +565,7 @@ ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, size_t buf_
     int nonce = random_uint32();
     DEBUGMSG(DEBUG, "nonce: %i\n", nonce);
 
-    struct ccnl_buf_s *interest = ccnl_mkSimpleInterest(prefix, &nonce);
+    struct ccnl_buf_s *interest = ccnl_mkSimpleInterest_scratch(buf, buf_len, prefix, &nonce);
     if(!interest){
         return -1;
     }


### PR DESCRIPTION
This patch introduces versions of `mkSimpleInterest` and `mkSimpleContent` that make use of a provided scratch space instead of calling malloc. I restructured the original functions to be simple wrapper functions that provide memory through `malloc` and pass the allocated memory to the new `*_scratch()` functions.

I also changed the RIOT adapter to call the `_scratch()` function directly with static memory.