### PR TITLE
ndn: add options to control Interest TLVs

### DIFF
--- a/src/ccn-lite-simu.c
+++ b/src/ccn-lite-simu.c
@@ -174,6 +174,7 @@ ccnl_client_TX(char node, char *name, int seqn, int nonce)
     struct ccnl_prefix_s *p;
     struct ccnl_buf_s *buf;
     struct ccnl_relay_s *relay = char2relay(node);
+    ccnl_interets_opts_u opts;
 
     DEBUGMSG(TRACE, "ccnl_client_tx node=%c: request %s #%d\n",
              node, name, seqn);
@@ -185,8 +186,13 @@ ccnl_client_TX(char node, char *name, int seqn, int nonce)
     //    p = ccnl_path_to_prefix(tmp);
     //    p->suite = suite;
     p = ccnl_URItoPrefix(tmp, theSuite, NULL, NULL);
+
+    if (theSuite == CCNL_SUITE_NDNTLV) {
+        opts.ndntlv.nonce = nonce;
+    }
+
     DEBUGMSG(TRACE, "  create interest for %s\n", ccnl_prefix_to_path(p));
-    buf = ccnl_mkSimpleInterest(p, &nonce);
+    buf = ccnl_mkSimpleInterest(p, &opts);
     free_prefix(p);
 
     // inject it into the relay:

--- a/src/ccnl-core/include/ccnl-pkt.h
+++ b/src/ccnl-core/include/ccnl-pkt.h
@@ -29,12 +29,25 @@
 #include "ccnl-buf.h"
 #include "ccnl-prefix.h"
 
+#ifdef USE_SUITE_NDNTLV
+#include "ccnl-pkt-ndntlv.h"
+#endif
+
 // packet flags:  0000ebtt
 #define CCNL_PKT_REQUEST    0x01 // "Interest"
 #define CCNL_PKT_REPLY      0x02 // "Object", "Data"
 #define CCNL_PKT_FRAGMENT   0x03 // "Fragment"
 #define CCNL_PKT_FRAG_BEGIN 0x04 // see also CCNL_DATA_FRAG_FLAG_FIRST etc
 #define CCNL_PKT_FRAG_END   0x08
+
+/**
+ * @brief Options for Interests of all TLV formats
+ */
+typedef union {
+#ifdef USE_SUITE_NDNTLV
+    struct ccnl_ndntlv_interest_opts_s ndntlv;      /**< options for NDN Interests */
+#endif
+} ccnl_interest_opts_u;
 
 struct ccnl_pktdetail_ccnb_s {
     int minsuffix, maxsuffix, aok, scope;

--- a/src/ccnl-nfn/src/ccnl-nfn-common.c
+++ b/src/ccnl-nfn/src/ccnl-nfn-common.c
@@ -77,6 +77,10 @@ ccnl_nfn_query2interest(struct ccnl_relay_s *ccnl,
                         struct configuration_s *config)
 {
     int nonce = rand();
+    ccnl_interest_opts_u int_opts;
+#ifdef USE_SUITE_NDNTLV
+    int_opts.ndntlv.nonce = nonce;
+#endif
     struct ccnl_pkt_s *pkt;
     struct ccnl_face_s *from;
     struct ccnl_interest_s *i;
@@ -109,7 +113,7 @@ ccnl_nfn_query2interest(struct ccnl_relay_s *ccnl,
     default:
         break;
     }
-    pkt->buf = ccnl_mkSimpleInterest(*prefix, &nonce);
+    pkt->buf = ccnl_mkSimpleInterest(*prefix, &int_opts);
     pkt->pfx = *prefix;
     *prefix = NULL;
     pkt->val.final_block_id = -1;
@@ -549,6 +553,10 @@ ccnl_nfn_mkKeepaliveInterest(struct ccnl_relay_s *ccnl,
 #else
     int nonce = rand();
 #endif
+    ccnl_interest_opts_u int_opts;
+#ifdef USE_SUITE_NDNTLV
+    int_opts.ndntlv.nonce = nonce;
+#endif
     struct ccnl_prefix_s *pfx;
     struct ccnl_pkt_s *pkt;
     struct ccnl_face_s *from;
@@ -598,7 +606,7 @@ ccnl_nfn_mkKeepaliveInterest(struct ccnl_relay_s *ccnl,
         default:
             break;
         }
-        pkt->buf = ccnl_mkSimpleInterest(pfx, &nonce);
+        pkt->buf = ccnl_mkSimpleInterest(pfx, &int_opts);
         pkt->pfx = pfx;
         //*prefix = NULL;
         pkt->val.final_block_id = -1;

--- a/src/ccnl-nfn/src/ccnl-nfn-requests.c
+++ b/src/ccnl-nfn/src/ccnl-nfn-requests.c
@@ -198,6 +198,10 @@ nfn_request_interest_pkt_new(struct ccnl_relay_s *ccnl, struct ccnl_prefix_s *pf
 #else
     int nonce = rand();
 #endif
+    ccnl_interest_opts_u int_opts;
+#ifdef USE_SUITE_NDNTLV
+    int_opts.ndntlv.nonce = nonce;
+#endif
     struct ccnl_pkt_s *pkt;
     (void)ccnl;
 
@@ -224,7 +228,7 @@ nfn_request_interest_pkt_new(struct ccnl_relay_s *ccnl, struct ccnl_prefix_s *pf
         break;
     }
     pkt->pfx = ccnl_prefix_dup(pfx);
-    pkt->buf = ccnl_mkSimpleInterest(pkt->pfx, &nonce);
+    pkt->buf = ccnl_mkSimpleInterest(pkt->pfx, &int_opts);
     pkt->val.final_block_id = -1;
 
     return pkt;

--- a/src/ccnl-pkt/include/ccnl-pkt-builder.h
+++ b/src/ccnl-pkt/include/ccnl-pkt-builder.h
@@ -22,6 +22,7 @@
 
 #include "ccnl-core.h"
 
+#include "ccnl-pkt.h"
 #include "ccnl-pkt-ccnb.h"
 #include "ccnl-pkt-ccntlv.h"
 #include "ccnl-pkt-cistlv.h"
@@ -81,13 +82,13 @@ ccnl_mkContent(struct ccnl_prefix_s *name, unsigned char *payload, int paylen, u
 
 
 struct ccnl_interest_s *
-ccnl_mkInterestObject(struct ccnl_prefix_s *name, int *nonce);
+ccnl_mkInterestObject(struct ccnl_prefix_s *name, ccnl_interest_opts_u *opts);
 
 struct ccnl_buf_s*
-ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, int *nonce);
+ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, ccnl_interest_opts_u *opts);
 
 void
-ccnl_mkInterest(struct ccnl_prefix_s *name, int *nonce, unsigned char *tmp,
+ccnl_mkInterest(struct ccnl_prefix_s *name, ccnl_interest_opts_u *opts, unsigned char *tmp,
                 int *len, int *offs);
 
 #endif

--- a/src/ccnl-pkt/include/ccnl-pkt-ndntlv.h
+++ b/src/ccnl-pkt/include/ccnl-pkt-ndntlv.h
@@ -23,7 +23,10 @@
 #ifndef CCNL_PKT_NDNTLV_H
 #define CCNL_PKT_NDNTLV_H
 
-#include "ccnl-core.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "ccnl-content.h"
 
 #define NDN_UDP_PORT                    6363
 #define NDN_DEFAULT_MTU                 4096
@@ -108,6 +111,16 @@ Values          Designation
 #define NDN_Marker_Timestamp			0xFC
 #define NDN_Marker_SequenceNumber		0xFE
 
+/**
+ * @brief NDN Interest options
+ */
+struct ccnl_ndntlv_interest_opts_s {
+    int32_t nonce;              /**< Nonce value */
+    /* Selectors */
+    bool mustbefresh;           /**< MustBeFresh Selector */
+    /* Guiders */
+    uint32_t interestlifetime;  /**< Interest Lifetime Guider */
+};
 
 #ifdef USE_SUITE_NDNTLV
 int
@@ -129,7 +142,7 @@ int
 ccnl_ndntlv_cMatch(struct ccnl_pkt_s *p, struct ccnl_content_s *c);
 
 int
-ccnl_ndntlv_prependInterest(struct ccnl_prefix_s *name, int scope, int *nonce,
+ccnl_ndntlv_prependInterest(struct ccnl_prefix_s *name, int scope, struct ccnl_ndntlv_interest_opts_s *opts,
                             int *offset, unsigned char *buf);
 
 int

--- a/src/ccnl-pkt/src/ccnl-pkt-builder.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-builder.c
@@ -225,12 +225,12 @@ ccnl_isFragment(unsigned char *buf, int len, int suite)
 #ifdef NEEDS_PACKET_CRAFTING
 
 struct ccnl_interest_s *
-ccnl_mkInterestObject(struct ccnl_prefix_s *name, int *nonce)
+ccnl_mkInterestObject(struct ccnl_prefix_s *name, ccnl_interest_opts_u *opts)
 {
     struct ccnl_interest_s *i = (struct ccnl_interest_s *) ccnl_calloc(1,
                                                                        sizeof(struct ccnl_interest_s));
     i->pkt = (struct ccnl_pkt_s *) ccnl_calloc(1, sizeof(struct ccnl_pkt_s));
-    i->pkt->buf = ccnl_mkSimpleInterest(name, nonce);
+    i->pkt->buf = ccnl_mkSimpleInterest(name, opts);
     i->pkt->pfx = ccnl_prefix_dup(name);
     i->flags |= CCNL_PIT_COREPROPAGATES;
     i->from = NULL;
@@ -238,7 +238,7 @@ ccnl_mkInterestObject(struct ccnl_prefix_s *name, int *nonce)
 }
 
 struct ccnl_buf_s*
-ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, int *nonce)
+ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, ccnl_interest_opts_u *opts)
 {
     struct ccnl_buf_s *buf = NULL;
     unsigned char *tmp;
@@ -249,7 +249,7 @@ ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, int *nonce)
     tmp = (unsigned char*) ccnl_malloc(CCNL_MAX_PACKET_SIZE);
     offs = CCNL_MAX_PACKET_SIZE;
 
-    ccnl_mkInterest(name, nonce, tmp, &len, &offs);
+    ccnl_mkInterest(name, opts, tmp, &len, &offs);
 
     if (len > 0)
         buf = ccnl_buf_new(tmp + offs, len);
@@ -258,7 +258,10 @@ ccnl_mkSimpleInterest(struct ccnl_prefix_s *name, int *nonce)
     return buf;
 }
 
-void ccnl_mkInterest(struct ccnl_prefix_s *name, int *nonce, unsigned char *tmp, int *len, int *offs) {
+void ccnl_mkInterest(struct ccnl_prefix_s *name, ccnl_interest_opts_u *opts,
+                     unsigned char *tmp, int *len, int *offs) {
+    ccnl_interest_opts_u default_opts;
+
     switch (name->suite) {
 #ifdef USE_SUITE_CCNB
         case CCNL_SUITE_CCNB:
@@ -289,15 +292,23 @@ void ccnl_mkInterest(struct ccnl_prefix_s *name, int *nonce, unsigned char *tmp,
 #endif
 #ifdef USE_SUITE_NDNTLV
         case CCNL_SUITE_NDNTLV:
+            if (!opts) {
+                opts = &default_opts;
+            }
+
+            if (!opts->ndntlv.nonce) {
+                opts->ndntlv.nonce = rand();
+            }
+
 #ifndef USE_SUITE_COMPRESSED
-            (*len) = ccnl_ndntlv_prependInterest(name, -1, nonce, offs, tmp);
+            (*len) = ccnl_ndntlv_prependInterest(name, -1, &(opts->ndntlv), offs, tmp);
 #else //USE_SUITE_COMPRESSED
             {
             struct ccnl_prefix_s *prefix = ccnl_pkt_prefix_compress(name);
             if(!prefix){
                 return;
             }
-            (*len) = ccnl_ndntlv_prependInterestCompressed(prefix, nonce, offs, tmp);
+            (*len) = ccnl_ndntlv_prependInterestCompressed(prefix, &(opts->ndntlv.nonce), offs, tmp);
             if(prefix->comp[0]){
                 ccnl_free(prefix->comp[0]); //only required in this special case
             }

--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -135,12 +135,14 @@ int ccnl_open_netif(kernel_pid_t if_pid, gnrc_nettype_t netreg_type);
  * @param[in] prefix    The name that is requested
  * @param[out] buf      Buffer to write the content chunk to
  * @param[in] buf_len   Size of @p buf
+ * @param[in] int_opts  Interest options (@ref ccnl_interest_opts_u)
  *
  * @return 0 on success
  * @return -1 on failure
  */
 int ccnl_send_interest(struct ccnl_prefix_s *prefix,
-                       unsigned char *buf, int buf_len);
+                       unsigned char *buf, int buf_len,
+                       ccnl_interest_opts_u *int_opts);
 
 /**
  * @brief Wait for incoming content chunk

--- a/src/ccnl-utils/ccn-lite-fetch.c
+++ b/src/ccnl-utils/ccn-lite-fetch.c
@@ -46,7 +46,11 @@ ccnl_fetchContentForChunkName(struct ccnl_prefix_s *prefix,
 #endif
 
     int nonce = random();
-    struct ccnl_buf_s * buf = ccnl_mkSimpleInterest(prefix, &nonce);
+    ccnl_interest_opts_u int_opts;
+#ifdef USE_SUITE_NDNTLV
+    int_opts.ndntlv.nonce = nonce;
+#endif
+    struct ccnl_buf_s * buf = ccnl_mkSimpleInterest(prefix, &int_opts);
 
     if(buf->datalen <= 0){
         fprintf(stderr, "Could not create interest message\n");

--- a/src/ccnl-utils/ccn-lite-mkI.c
+++ b/src/ccnl-utils/ccn-lite-mkI.c
@@ -39,6 +39,7 @@ main(int argc, char *argv[])
     uint32_t nonce;
     int isLambda = 0;
     unsigned int chunknum = UINT_MAX;
+    ccnl_interest_opts_u int_opts;
 
     (void) minSuffix;
     (void) maxSuffix;
@@ -146,7 +147,10 @@ Usage:
     }
 
     prefix->suite = packettype;
-    struct ccnl_buf_s *buf = ccnl_mkSimpleInterest(prefix, (int*)&nonce);
+#ifdef USE_SUITE_NDNTLV
+    int_opts.ndntlv.nonce = nonce;
+#endif
+    struct ccnl_buf_s *buf = ccnl_mkSimpleInterest(prefix, &int_opts);
 
     if (buf->datalen <= 0) {
         DEBUGMSG(ERROR, "internal error: empty packet\n");

--- a/src/ccnl-utils/ccn-lite-peek.c
+++ b/src/ccnl-utils/ccn-lite-peek.c
@@ -148,12 +148,16 @@ usage:
         int nonce = random();
         int rc;
         struct ccnl_face_s dummyFace;
+        ccnl_interest_opts_u int_opts;
+#ifdef USE_SUITE_NDNTLV
+        int_opts.ndntlv.nonce = nonce;
+#endif
 
         DEBUGMSG(TRACE, "sending request, iteration %d\n", cnt);
 
         memset(&dummyFace, 0, sizeof(dummyFace));
 
-        buf = ccnl_mkSimpleInterest(prefix, &nonce);
+        buf = ccnl_mkSimpleInterest(prefix, &int_opts);
 
         DEBUGMSG(DEBUG, "interest has %zd bytes\n", buf->datalen);
 /*

--- a/src/ccnl-utils/ccn-lite-simplenfn.c
+++ b/src/ccnl-utils/ccn-lite-simplenfn.c
@@ -188,9 +188,13 @@ usage:
         goto done;
     for (;;) {
         int nonce = random();
+        ccnl_interest_opts_u int_opts;
+#ifdef USE_SUITE_NDNTLV
+        int_opts.ndntlv.nonce = nonce;
+#endif
 
         buf = ccnl_mkSimpleInterest(prefix,
-                         &nonce);
+                         &int_opts);
 
         DEBUGMSG(TRACE,
                  "sending interest(prefix=%s, suite=%s)\n",


### PR DESCRIPTION
This patch extends the `_mk(Simple)Interest()` functions by another parameter in order to be able to control Interest TLV options.

This is *Work in Progress* and should not be merged yet, because I did not adapt every application to this new signature (e.g. the nfn code). It works for RIOT, though.