### PR TITLE
use malloc-free ccnl_prefix_to_str() in internal functions

### DIFF
--- a/src/ccnl-core/include/ccnl-defs.h
+++ b/src/ccnl-core/include/ccnl-defs.h
@@ -39,9 +39,12 @@
 #if defined(CCNL_ARDUINO) || defined(CCNL_RIOT)
 # define CCNL_MAX_INTERFACES             1
 # define CCNL_MAX_IF_QLEN                14
-# ifndef CCNL_MAX_PACKET_SIZE
+#ifndef CCNL_MAX_PACKET_SIZE
 # define CCNL_MAX_PACKET_SIZE            120
-# endif
+#endif
+#ifndef CCNL_MAX_PREFIX_SIZE
+# define CCNL_MAX_PREFIX_SIZE            50
+#endif
 # define CCNL_MAX_ADDRESS_LEN            8
 # define CCNL_MAX_NAME_COMP              8
 # define CCNL_DEFAULT_MAX_PIT_ENTRIES    20
@@ -52,12 +55,14 @@
 # define CCNL_MAX_ADDRESS_LEN            6
 # define CCNL_MAX_NAME_COMP              16
 # define CCNL_DEFAULT_MAX_PIT_ENTRIES    100
+# define CCNL_MAX_PREFIX_SIZE            2048
 #else
 # define CCNL_MAX_INTERFACES             10
 # define CCNL_MAX_IF_QLEN                64
 # define CCNL_MAX_PACKET_SIZE            8096
 # define CCNL_MAX_ADDRESS_LEN            6
 # define CCNL_MAX_NAME_COMP              64
+# define CCNL_MAX_PREFIX_SIZE            2048
 # define CCNL_DEFAULT_MAX_PIT_ENTRIES    (-1)
 #endif
 

--- a/src/ccnl-core/include/ccnl-prefix.h
+++ b/src/ccnl-core/include/ccnl-prefix.h
@@ -178,11 +178,27 @@ int
 ccnl_URItoComponents(char **compVector, unsigned int *compLens, char *uri);
 
 #ifndef CCNL_LINUXKERNEL
-void ccnl_prefix_to_str_detailed(struct ccnl_prefix_s *pr, int ccntlv_skip, int escape_components, int call_slash,
-                                char *buf, int buflen);
+/**
+ * @brief Transforms a Prefix into a URI, separated by '/'
+ *
+ * @param[in]  pr                   The prefix that should be transformed
+ * @param[in]  ccntlv_skip          Flag to enable skipping of CCNL_TLV fields
+ * @param[in]  escape_components    Flag to enable escaping components
+ * @param[in]  call_slash Flag to   enable call_slash
+ * @param[out] buf                  buffer to write the URI to
+ * @param[in]  buf_len              length of buffer @p buf
+ *
+ * @return the created URI @p buf
+*/
+char *
+ccnl_prefix_to_str_detailed(struct ccnl_prefix_s *pr, int ccntlv_skip, int escape_components, int call_slash,
+                            char *buf, int buflen);
 
 /**
- * @brief Transforms a Prefix into a URI, separated bei '/', add additional information 
+ * @brief Transforms a Prefix into a URI, separated by '/'
+ *
+ * @note A buffer is allocated via `malloc` and passed to
+ *       @ref ccnl_prefix_to_str_detailed
  *
  * @param[in] pr                The prefix that should be transformed   
  * @param[in] ccntlv_skip       Flag to enable skipping of CCNL_TLV fields

--- a/src/ccnl-core/src/ccnl-content.c
+++ b/src/ccnl-core/src/ccnl-content.c
@@ -27,6 +27,7 @@
 #include "ccnl-pkt.h"
 #include "ccnl-os-time.h"
 #include "ccnl-logging.h"
+#include "ccnl-defs.h"
 #else
 #include <ccnl-content.h>
 #include <ccnl-malloc.h>
@@ -42,10 +43,12 @@ ccnl_content_new(struct ccnl_pkt_s **pkt)
 {
     struct ccnl_content_s *c;
 
-    char *s = NULL;
+    char s[CCNL_MAX_PREFIX_SIZE];
+    (void) s;
+
     DEBUGMSG_CORE(TRACE, "ccnl_content_new %p <%s [%d]>\n",
-             (void*) *pkt, (s = ccnl_prefix_to_path((*pkt)->pfx)), ((*pkt)->pfx->chunknum)? *((*pkt)->pfx->chunknum) : -1);
-    ccnl_free(s);
+             (void*) *pkt, ccnl_prefix_to_str((*pkt)->pfx, s, CCNL_MAX_PREFIX_SIZE),
+             ((*pkt)->pfx->chunknum)? *((*pkt)->pfx->chunknum) : -1);
 
     c = (struct ccnl_content_s *) ccnl_calloc(1, sizeof(struct ccnl_content_s));
     if (!c)

--- a/src/ccnl-core/src/ccnl-dump.c
+++ b/src/ccnl-core/src/ccnl-dump.c
@@ -67,6 +67,9 @@ ccnl_dump(int lev, int typ, void *p)
     struct ccnl_content_s *con = (struct ccnl_content_s *) p;
     int i, k;
 
+    char s[CCNL_MAX_PREFIX_SIZE];
+    (void) s;
+
     #define INDENT(lev)   for (i = 0; i < (lev); i++) CONSOLE("  ")
 
     switch (typ) {
@@ -81,7 +84,7 @@ ccnl_dump(int lev, int typ, void *p)
         case CCNL_PREFIX:
             INDENT(lev);
             CONSOLE("%p PREFIX len=%d val=%s\n",
-                    (void *) pre, pre->compcnt, ccnl_prefix_to_path(pre));
+                    (void *) pre, pre->compcnt, ccnl_prefix_to_str(pre,s,CCNL_MAX_PREFIX_SIZE));
             break;
         case CCNL_RELAY:
             INDENT(lev);
@@ -317,13 +320,14 @@ int
 get_prefix_dump(int lev, void *p, int *len, char** val)
 {
     struct ccnl_prefix_s   *pre = (struct ccnl_prefix_s   *) p;
+    char s[CCNL_MAX_PREFIX_SIZE];
 //    int i;
 //    INDENT(lev);
     //*prefix =  (void *) pre;
     (void)lev;
     *len = pre->compcnt;
     //*val = ccnl_prefix_to_path(pre);
-    sprintf(*val, "%s", ccnl_prefix_to_path(pre));
+    sprintf(*val, "%s", ccnl_prefix_to_str(pre,s,CCNL_MAX_PREFIX_SIZE));
     return 1;
 }
 

--- a/src/ccnl-core/src/ccnl-http-status.c
+++ b/src/ccnl-core/src/ccnl-http-status.c
@@ -199,6 +199,7 @@ ccnl_http_status(struct ccnl_relay_s *ccnl, struct ccnl_http_s *http)
     struct ccnl_forward_s *fwd;
     struct ccnl_interest_s *ipt;
     struct ccnl_buf_s *bpt;
+    char s[CCNL_MAX_PREFIX_SIZE];
 
     strcpy(txt, hdr);
     len += sprintf(txt+len,
@@ -243,7 +244,7 @@ ccnl_http_status(struct ccnl_relay_s *ccnl, struct ccnl_http_s *http)
                 sprintf(fname, "?");
             len += sprintf(txt+len,
                            "<li>via %4s: <font face=courier>%s</font>\n",
-                           fname, ccnl_prefix_to_path(fwda[i]->prefix));
+                           fname, ccnl_prefix_to_str(fwda[i]->prefix,s,CCNL_MAX_PREFIX_SIZE));
         }
         ccnl_free(fwda);
     }

--- a/src/ccnl-core/src/ccnl-interest.c
+++ b/src/ccnl-core/src/ccnl-interest.c
@@ -101,7 +101,7 @@ int
 ccnl_interest_append_pending(struct ccnl_interest_s *i,  struct ccnl_face_s *from)
 {
     struct ccnl_pendint_s *pi, *last = NULL;
-    char *s = NULL;
+    char s[CCNL_MAX_PREFIX_SIZE];
     DEBUGMSG_CORE(TRACE, "ccnl_append_pending\n");
 
     for (pi = i->pending; pi; pi = pi->next) { // check whether already listed
@@ -119,8 +119,8 @@ ccnl_interest_append_pending(struct ccnl_interest_s *i,  struct ccnl_face_s *fro
     }
 
     DEBUGMSG_CORE(DEBUG, "  appending a new pendint entry %p <%s>(%p)\n",
-                  (void *) pi, (s = ccnl_prefix_to_path(i->pkt->pfx)), (void*)i->pkt->pfx);
-    ccnl_free(s);
+                  (void *) pi, ccnl_prefix_to_str(i->pkt->pfx,s,CCNL_MAX_PREFIX_SIZE),
+                  (void *) i->pkt->pfx);
     pi->face = from;
     pi->last_used = CCNL_NOW();
     if (last)
@@ -134,7 +134,7 @@ int
 ccnl_interest_remove_pending(struct ccnl_interest_s *i, struct ccnl_face_s *face)
 {
     int found = 0;
-    char *s = NULL;
+    char s[CCNL_MAX_PREFIX_SIZE];
     struct ccnl_pendint_s *prev = NULL;
     struct ccnl_pendint_s *pend = i->pending;
     DEBUGMSG_CORE(TRACE, "ccnl_interest_remove_pending\n");
@@ -142,7 +142,7 @@ ccnl_interest_remove_pending(struct ccnl_interest_s *i, struct ccnl_face_s *face
         if (face->faceid == pend->face->faceid) {
             DEBUGMSG_CFWD(INFO, "  removed face (%s) for interest %s\n",
                           ccnl_addr2ascii(&pend->face->peer),
-                          (s = ccnl_prefix_to_path(i->pkt->pfx)));
+                          ccnl_prefix_to_str(i->pkt->pfx,s,CCNL_MAX_PREFIX_SIZE));
             found++;
             if (prev) {
                 prev->next = pend->next;
@@ -158,7 +158,5 @@ ccnl_interest_remove_pending(struct ccnl_interest_s *i, struct ccnl_face_s *face
             pend = pend->next;
         }
     }
-    if (s)
-        ccnl_free(s);
     return found;
 }

--- a/src/ccnl-core/src/ccnl-mgmt.c
+++ b/src/ccnl-core/src/ccnl-mgmt.c
@@ -1560,6 +1560,7 @@ ccnl_mgmt_echo(struct ccnl_relay_s *ccnl, struct ccnl_buf_s *orig,
     unsigned char *action, *suite=0, h[10];
     char *cp = "echoserver cmd failed";
     int rc = -1;
+    char s[CCNL_MAX_PREFIX_SIZE];
 
     int len = 0, len3;
 
@@ -1619,7 +1620,7 @@ ccnl_mgmt_echo(struct ccnl_relay_s *ccnl, struct ccnl_buf_s *orig,
     if (suite && *suite >= 0 && *suite < CCNL_SUITE_LAST && p->compcnt > 0) {
         p->suite = *suite;
         DEBUGMSG(TRACE, "mgmt: activating echo server for %s, suite=%s\n",
-                 ccnl_prefix_to_path(p), ccnl_suite2str(*suite));
+                 ccnl_prefix_to_str(p,s,CCNL_MAX_PREFIX_SIZE), ccnl_suite2str(*suite));
         ccnl_echo_add(ccnl, ccnl_prefix_clone(p));
         cp = "echoserver cmd worked";
     } else {
@@ -1643,7 +1644,7 @@ Bail:
     // prepare FWDENTRY
     len3 = ccnl_ccnb_mkHeader(fwdentry_buf, CCNL_DTAG_PREFIX, CCN_TT_DTAG);
     len3 += ccnl_ccnb_mkStrBlob(fwdentry_buf+len3, CCN_DTAG_ACTION, CCN_TT_DTAG, cp);
-    len3 += ccnl_ccnb_mkStrBlob(fwdentry_buf+len3, CCN_DTAG_NAME, CCN_TT_DTAG, ccnl_prefix_to_path(p)); // prefix
+    len3 += ccnl_ccnb_mkStrBlob(fwdentry_buf+len3, CCN_DTAG_NAME, CCN_TT_DTAG, ccnl_prefix_to_str(p,s,CCNL_MAX_PREFIX_SIZE)); // prefix
 
     //    len3 += ccnl_ccnb_mkStrBlob(fwdentry_buf+len3, CCN_DTAG_FACEID, CCN_TT_DTAG, (char*) faceid);
     memset(h,0,sizeof(h));
@@ -1678,6 +1679,7 @@ ccnl_mgmt_prefixreg(struct ccnl_relay_s *ccnl, struct ccnl_buf_s *orig,
     unsigned char *action, *faceid, *suite=0, h[10];
     char *cp = "prefixreg cmd failed";
     int rc = -1;
+    char s[CCNL_MAX_PREFIX_SIZE];
 
     int len = 0, len3;
 //    unsigned char contentobj[2000];
@@ -1745,7 +1747,7 @@ ccnl_mgmt_prefixreg(struct ccnl_relay_s *ccnl, struct ccnl_buf_s *orig,
         p->suite = suite[0];
 
         DEBUGMSG(TRACE, "mgmt: adding prefix %s to faceid=%s, suite=%s\n",
-                 ccnl_prefix_to_path(p), faceid, ccnl_suite2str(suite[0]));
+                 ccnl_prefix_to_str(p,s,CCNL_MAX_PREFIX_SIZE), faceid, ccnl_suite2str(suite[0]));
 
         for (f = ccnl->faces; f && f->faceid != fi; f = f->next);
         if (!f) goto Bail;
@@ -1784,7 +1786,7 @@ Bail:
     // prepare FWDENTRY
     len3 = ccnl_ccnb_mkHeader(fwdentry_buf, CCNL_DTAG_PREFIX, CCN_TT_DTAG);
     len3 += ccnl_ccnb_mkStrBlob(fwdentry_buf+len3, CCN_DTAG_ACTION, CCN_TT_DTAG, cp);
-    len3 += ccnl_ccnb_mkStrBlob(fwdentry_buf+len3, CCN_DTAG_NAME, CCN_TT_DTAG, ccnl_prefix_to_path(p)); // prefix
+    len3 += ccnl_ccnb_mkStrBlob(fwdentry_buf+len3, CCN_DTAG_NAME, CCN_TT_DTAG, ccnl_prefix_to_str(p,s,CCNL_MAX_PREFIX_SIZE)); // prefix
 
     len3 += ccnl_ccnb_mkStrBlob(fwdentry_buf+len3, CCN_DTAG_FACEID, CCN_TT_DTAG, (char*) faceid);
     memset(h,0,sizeof(h));
@@ -1819,6 +1821,7 @@ ccnl_mgmt_addcacheobject(struct ccnl_relay_s *ccnl, struct ccnl_buf_s *orig,
     unsigned int chunknum = 0, chunkflag = 0;
     int num, typ, num_of_components = -1, suite = 2;
     struct ccnl_prefix_s *prefix_new;
+    char s[CCNL_MAX_PREFIX_SIZE];
 
     buf = prefix->comp[3];
     buflen = prefix->complen[3];
@@ -1879,14 +1882,16 @@ ccnl_mgmt_addcacheobject(struct ccnl_relay_s *ccnl, struct ccnl_buf_s *orig,
     prefix_new->suite = suite;
 
     DEBUGMSG(TRACE, "  mgmt: adding object %s to cache (suite=%s)\n",
-             ccnl_prefix_to_path(ccnl_prefix_dup(prefix_new)), ccnl_suite2str(suite));
+             ccnl_prefix_to_str(ccnl_prefix_dup(prefix_new),s,CCNL_MAX_PREFIX_SIZE),
+             ccnl_suite2str(suite));
 
     //Reply MSG
     if (h)
         ccnl_free(h);
     h = ccnl_malloc(300);
 
-    sprintf((char *)h, "received add to cache request, inizializing callback for %s", ccnl_prefix_to_path(prefix_new));
+    sprintf((char *)h, "received add to cache request, inizializing callback for %s",
+            ccnl_prefix_to_str(prefix_new,s,CCNL_MAX_PREFIX_SIZE));
     ccnl_mgmt_return_ccn_msg(ccnl, orig, prefix, from,
                              "addcacheobject", (char *)h);
     if (h)

--- a/src/ccnl-fwd/src/ccnl-echo.c
+++ b/src/ccnl-fwd/src/ccnl-echo.c
@@ -34,8 +34,10 @@ ccnl_echo_request(struct ccnl_relay_s *relay, struct ccnl_face_s *inface,
     unsigned char *ucp;
     int len, enc;
     struct ccnl_prefix_s *pfx2 = NULL;
+    char s[CCNL_MAX_PREFIX_SIZE];
+    (void) s;
 
-    DEBUGMSG(DEBUG, "echo request for <%s>\n", ccnl_prefix_to_path(pfx));
+    DEBUGMSG(DEBUG, "echo request for <%s>\n", ccnl_prefix_to_str(pfx,s,CCNL_MAX_PREFIX_SIZE));
 
 //    if (pfx->chunknum) {
         // mkSimpleContent adds the chunk number, so remove it here
@@ -55,7 +57,7 @@ ccnl_echo_request(struct ccnl_relay_s *relay, struct ccnl_face_s *inface,
 #endif
 
     t = time(NULL);
-    s = ccnl_prefix_to_path(pfx);
+    ccnl_prefix_to_str(pfx,s,CCNL_MAX_PREFIX_SIZE);
 
     cp = ccnl_malloc(strlen(s) + 60);
     sprintf(cp, "%s\n%suptime %s\n", s, ctime(&t), timestamp());

--- a/src/ccnl-fwd/src/ccnl-fwd.c
+++ b/src/ccnl-fwd/src/ccnl-fwd.c
@@ -63,8 +63,9 @@ ccnl_fwd_handleContent(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
                        struct ccnl_pkt_s **pkt)
 {
     struct ccnl_content_s *c;
+    char s[CCNL_MAX_PREFIX_SIZE];
+    (void) s;
 
-    char *s = NULL;
 #ifdef USE_NFN
     int nonce = 0;
     if (pkt != NULL && (*pkt) != NULL && (*pkt)->s.ndntlv.nonce != NULL) {
@@ -74,18 +75,17 @@ ccnl_fwd_handleContent(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     }
 
     DEBUGMSG_CFWD(INFO, "  incoming data=<%s>%s (nfnflags=%d) nonce=%i from=%s\n",
-                  (s = ccnl_prefix_to_path((*pkt)->pfx)),
+                  ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE),
                   ccnl_suite2str((*pkt)->suite),
                   (*pkt)->pfx->nfnflags, nonce,
                   ccnl_addr2ascii(from ? &from->peer : NULL));
     DEBUGMSG_CFWD(INFO, "  data %.*s\n", (*pkt)->contlen, (*pkt)->content);
 #else
     DEBUGMSG_CFWD(INFO, "  incoming data=<%s>%s from=%s\n",
-                  (s = ccnl_prefix_to_path((*pkt)->pfx)),
+                  ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE),
                   ccnl_suite2str((*pkt)->suite),
                   ccnl_addr2ascii(from ? &from->peer : NULL));
 #endif
-    ccnl_free(s); 
 
 #if defined(USE_SUITE_CCNB) && defined(USE_SIGNATURES)
 //  FIXME: mgmt messages for NDN and other suites?
@@ -230,7 +230,8 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     struct ccnl_interest_s *i;
     struct ccnl_content_s *c;
     int propagate= 0;
-    char *s = NULL;
+    char s[CCNL_MAX_PREFIX_SIZE];
+    (void) s;
     int32_t nonce = 0;
     if (pkt != NULL && (*pkt) != NULL && (*pkt)->s.ndntlv.nonce != NULL) {
         if ((*pkt)->s.ndntlv.nonce->datalen == 4) {
@@ -241,16 +242,15 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
 
 #ifndef CCNL_LINUXKERNEL
     DEBUGMSG_CFWD(INFO, "  incoming interest=<%s>%s nonce=%"PRIi32" from=%s\n",
-                  (s = ccnl_prefix_to_path((*pkt)->pfx)),
+                  ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE),
                   ccnl_suite2str((*pkt)->suite), nonce,
                   ccnl_addr2ascii(from ? &from->peer : NULL));
 #else
     DEBUGMSG_CFWD(INFO, "  incoming interest=<%s>%s nonce=%d from=%s\n",
-                  (s = ccnl_prefix_to_path((*pkt)->pfx)),
+                  ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE),
                   ccnl_suite2str((*pkt)->suite), nonce,
                   ccnl_addr2ascii(from ? &from->peer : NULL));
 #endif
-    ccnl_free(s);
 
 #ifdef USE_DUP_CHECK
 
@@ -379,14 +379,13 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
         DEBUGMSG_CFWD(DEBUG,
                       "  created new interest entry %p (prefix=%s, nfnflags=%d)\n",
                       (void *) i,
-                      (s = ccnl_prefix_to_path(i->pkt->pfx)),
+                      ccnl_prefix_to_str(i->pkt->pfx,s,CCNL_MAX_PREFIX_SIZE),
                       i->pkt->pfx->nfnflags);
 #else
         DEBUGMSG_CFWD(DEBUG,
                       "  created new interest entry %p (prefix=%s)\n",
-                      (void *) i, (s = ccnl_prefix_to_path(i->pkt->pfx)));
+                      (void *) i, ccnl_prefix_to_str(i->pkt->pfx,s,CCNL_MAX_PACKET_SIZE));
 #endif
-    ccnl_free(s);
     }
     if (i) { // store the I request, for the incoming face (Step 3)
         DEBUGMSG_CFWD(DEBUG, "  appending interest entry %p\n", (void *) i);
@@ -820,11 +819,12 @@ ccnl_set_tap(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
              tapCallback callback)
 {
     struct ccnl_forward_s *fwd, **fwd2;
+    char s[CCNL_MAX_PREFIX_SIZE];
+    (void) s;
 
-    char *s = NULL;
     DEBUGMSG_CFWD(INFO, "setting tap for <%s>, suite %s\n",
-             (s = ccnl_prefix_to_path(pfx)), ccnl_suite2str(pfx->suite));
-    ccnl_free(s);
+             ccnl_prefix_to_str(pfx,s,CCNL_MAX_PREFIX_SIZE),
+             ccnl_suite2str(pfx->suite));
 
     for (fwd = relay->fib; fwd; fwd = fwd->next) {
         if (fwd->suite == pfx->suite &&

--- a/src/ccnl-pkt/src/ccnl-pkt-builder.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-builder.c
@@ -334,11 +334,12 @@ ccnl_mkSimpleContent(struct ccnl_prefix_s *name,
     int len = 0, contentpos = 0, offs;
     struct ccnl_prefix_s *prefix;
     (void)prefix;
+    char s[CCNL_MAX_PREFIX_SIZE];
+    (void) s;
 
-    char *s = NULL;
     DEBUGMSG_CUTL(DEBUG, "mkSimpleContent (%s, %d bytes)\n",
-                  (s = ccnl_prefix_to_path(name)), paylen);
-    ccnl_free(s);
+                  ccnl_prefix_to_str(name, s, CCNL_MAX_PREFIX_SIZE),
+                  paylen);
 
     tmp = (unsigned char*) ccnl_malloc(CCNL_MAX_PACKET_SIZE);
     offs = CCNL_MAX_PACKET_SIZE;

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -106,11 +106,6 @@ static int _ccnl_suite = CCNL_SUITE_NDNTLV;
 struct ccnl_interest_s* ccnl_interest_remove(struct ccnl_relay_s *ccnl,
                      struct ccnl_interest_s *i);
 int ccnl_pkt2suite(unsigned char *data, int len, int *skip);
-
-char* ccnl_prefix_to_path_detailed(struct ccnl_prefix_s *pr,
-                    int ccntlv_skip, int escape_components, int call_slash);
-#define ccnl_prefix_to_path(P) ccnl_prefix_to_path_detailed(P, 1, 0, 0)
-
 char* ccnl_addr2ascii(sockunion *su);
 void ccnl_core_addToCleanup(struct ccnl_buf_s *buf);
 const char* ccnl_suite2str(int suite);

--- a/src/ccnl-utils/ccnl-common.c
+++ b/src/ccnl-utils/ccnl-common.c
@@ -76,8 +76,6 @@ int debug_level = WARNING;
 #endif //USE_DEBUG_MALLOC
 #define free_2ptr_list(a,b)     ccnl_free(a), ccnl_free(b)
 
-#define ccnl_prefix_to_path(P) ccnl_prefix_to_path_detailed(P, 1, 0, 0)
-
 struct ccnl_prefix_s* ccnl_prefix_new(int suite, int cnt);
 int ccnl_pkt_prependComponent(int suite, char *src, int *offset, unsigned char *buf);
 


### PR DESCRIPTION
This patch adjusts ccn-lite internal functions (e.g. in the core and fwd libs) to use the malloc-free `ccnl_prefix_to_str()` instead of `ccnl_prefix_to_path()`.

This is currently untested. I will do some tests with RIOT, @blacksheeep could you have a quick test with Linux / MAC?

@mfrey could you also have a look over the changes?