### PR TITLE
cmake: control building the unit tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,11 @@ set(CMAKE_C_COMPILER_WORKS 1)
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 set(CMAKE_SYSTEM_NAME Generic)
 
-enable_testing()
+option(BUILD_TESTING "Build the testing tree." ON)
+
+if (BUILD_TESTING)
+    enable_testing()
+endif()
 
 # CCNL flags
 set(CCNL_BASIC_FLAGS

--- a/src/ccnl-core/CMakeLists.txt
+++ b/src/ccnl-core/CMakeLists.txt
@@ -11,11 +11,12 @@ endif()
 
 file(GLOB SOURCES "src/*.c")
 file(GLOB HEADERS "include/*.h")
-file(GLOB TEST "test/unit.c")
 
 add_library(${PROJECT_NAME} STATIC ${SOURCES} ${HEADERS})
 
+if (BUILD_TESTING)
+    file(GLOB TEST "test/unit.c")
+    add_executable(${PROJECT_NAME}_test "test/ccnl_core_unit_test.c")
+    add_test(NAME ccnl_core COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_test 0)
+endif()
 
-add_executable(${PROJECT_NAME}_test "test/ccnl_core_unit_test.c")
-
-add_test(NAME ccnl_core COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_test 0)


### PR DESCRIPTION
The compilation of unit tests fails for RIOT, when building for an architecture like arm cortex (!= x86_64). This patch introduces a flag to disable the compilation of building tests. We can then leverage this flag on the RIOT side to disable the unit tests for those platforms.