### PR TITLE
ndntlv: add InterestLifetime parsing

### DIFF
--- a/src/ccnl-core/include/ccnl-interest.h
+++ b/src/ccnl-core/include/ccnl-interest.h
@@ -30,7 +30,7 @@
 struct ccnl_pendint_s { // pending interest
     struct ccnl_pendint_s *next; // , *prev;
     struct ccnl_face_s *face;
-    int last_used;
+    uint32_t last_used;
 };
 
 struct ccnl_interest_s {
@@ -39,9 +39,10 @@ struct ccnl_interest_s {
     struct ccnl_face_s *from;
     struct ccnl_pendint_s *pending; // linked list of faces wanting that content
     unsigned short flags;
+    uint32_t lifetime;
 #define CCNL_PIT_COREPROPAGATES    0x01
 #define CCNL_PIT_TRACED            0x02
-    int last_used;
+    uint32_t last_used;
     int retries;
 #ifdef USE_NFN_REQUESTS
     struct ccnl_interest_s *keepalive; // the keepalive interest dispatched for this interest

--- a/src/ccnl-core/include/ccnl-pkt.h
+++ b/src/ccnl-core/include/ccnl-pkt.h
@@ -67,6 +67,7 @@ struct ccnl_pktdetail_ndntlv_s {
     int minsuffix, maxsuffix, mbf, scope;
     struct ccnl_buf_s *nonce;      /**< nonce */
     struct ccnl_buf_s *ppkl;       /**< publisher public key locator */
+    uint32_t interestlifetime;     /**< interest lifetime */
 };
 
 struct ccnl_pkt_s {

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -341,6 +341,8 @@ ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
     if (!i)
         return NULL;
     i->pkt = *pkt;
+    /* currently, the aging function relies on seconds rather than on milli seconds */
+    i->lifetime = (*pkt)->s.ndntlv.interestlifetime / 1000;
     *pkt = NULL;
     i->flags |= CCNL_PIT_COREPROPAGATES;
     i->from = from;
@@ -799,7 +801,7 @@ ccnl_do_ageing(void *ptr, void *dummy)
     }
     while (i) { // CONFORM: "Entries in the PIT MUST timeout rather
                 // than being held indefinitely."
-        if ((i->last_used + CCNL_INTEREST_TIMEOUT) <= t ||
+        if ((i->last_used + i->lifetime) <= (uint32_t) t ||
                                 i->retries >= CCNL_MAX_INTEREST_RETRANSMIT) {
 #ifdef USE_NFN_REQUESTS
                 if (!ccnl_nfnprefix_isNFN(i->pkt->pfx)) {

--- a/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
@@ -133,6 +133,9 @@ ccnl_ndntlv_bytes2pkt(unsigned int pkttype, unsigned char *start,
     pkt->s.ndntlv.scope = 3;
     pkt->s.ndntlv.maxsuffix = CCNL_MAX_NAME_COMP;
 
+    /* set default lifetime, in case InterestLifetime guider is absent */
+    pkt->s.ndntlv.interestlifetime = CCNL_INTEREST_TIMEOUT;
+
     oldpos = *data - start;
     while (ccnl_ndntlv_dehead(data, datalen, (int*) &typ, &len) == 0) {
         unsigned char *cp = *data;
@@ -252,6 +255,9 @@ ccnl_ndntlv_bytes2pkt(unsigned int pkttype, unsigned char *start,
                 cp += i;
                 len2 -= i;
             }
+            break;
+        case NDN_TLV_InterestLifetime:
+            pkt->s.ndntlv.interestlifetime = ccnl_ndntlv_nonNegInt(*data, len);
             break;
         case NDN_TLV_Frag_BeginEndFields:
             pkt->val.seqno = ccnl_ndntlv_nonNegInt(*data, len);


### PR DESCRIPTION
This patch adds NDN InterestLifetime parsing for the InterestLifetime Guider.