### PR TITLE
ndntlv: add Data options

### DIFF
--- a/src/ccn-lite-simu.c
+++ b/src/ccn-lite-simu.c
@@ -156,7 +156,7 @@ ccnl_simu_add2cache(char node, const char *name, int seqn, void *data, int len)
     pkt = ccnl_calloc(1, sizeof(*pkt));
     pkt->pfx = ccnl_URItoPrefix(tmp, theSuite, NULL, NULL);
     DEBUGMSG(VERBOSE, "  %s\n", ccnl_prefix_to_path(pkt->pfx));
-    pkt->buf = ccnl_mkSimpleContent(pkt->pfx, data, len, &dataoffset);
+    pkt->buf = ccnl_mkSimpleContent(pkt->pfx, data, len, &dataoffset, NULL);
     pkt->content = pkt->buf->data + dataoffset;
     pkt->contlen = len;
     c = ccnl_content_new(relay, &pkt);

--- a/src/ccnl-core/include/ccnl-content.h
+++ b/src/ccnl-core/include/ccnl-content.h
@@ -23,6 +23,9 @@
 #ifndef CCNL_CONTENT_H
 #define CCNL_CONTENT_H
 
+#include <stdbool.h>
+#include <stdint.h>
+
 struct ccnl_pkt_s;
 struct ccnl_prefix_s;
 
@@ -34,7 +37,13 @@ struct ccnl_content_s {
 #define CCNL_CONTENT_FLAGS_STALE   0x02
     // NON-CONFORM: "The [ContentSTore] MUST also implement the Staleness Bit."
     // >> CCNL: currently no stale bit, old content is fully removed <<
-    int last_used;
+    uint32_t last_used;
+
+#ifdef USE_SUITE_NDNTLV
+    uint32_t freshnessperiod;
+    bool stale;
+#endif
+
     int served_cnt;
 };
 

--- a/src/ccnl-core/include/ccnl-pkt.h
+++ b/src/ccnl-core/include/ccnl-pkt.h
@@ -41,13 +41,22 @@
 #define CCNL_PKT_FRAG_END   0x08
 
 /**
- * @brief Options for Interests of all TLV formats
+ * @brief Options for Interest messages of all TLV formats
  */
 typedef union {
 #ifdef USE_SUITE_NDNTLV
-    struct ccnl_ndntlv_interest_opts_s ndntlv;      /**< options for NDN Interests */
+    struct ccnl_ndntlv_interest_opts_s ndntlv;      /**< options for NDN Interest messages */
 #endif
 } ccnl_interest_opts_u;
+
+/**
+ * @brief Options for Data messages of all TLV formats
+ */
+typedef union {
+#ifdef USE_SUITE_NDNTLV
+    struct ccnl_ndntlv_data_opts_s ndntlv;      /**< options for NDN Data messages */
+#endif
+} ccnl_data_opts_u;
 
 struct ccnl_pktdetail_ccnb_s {
     int minsuffix, maxsuffix, aok, scope;
@@ -63,11 +72,17 @@ struct ccnl_pktdetail_iottlv_s {
     int ttl;
 };
 
+/**
+ * @brief Packet details for the NDN TLV format
+ */
 struct ccnl_pktdetail_ndntlv_s {
+    /* Interest */
     int minsuffix, maxsuffix, mbf, scope;
     struct ccnl_buf_s *nonce;      /**< nonce */
     struct ccnl_buf_s *ppkl;       /**< publisher public key locator */
     uint32_t interestlifetime;     /**< interest lifetime */
+    /* Data */
+    uint32_t freshnessperiod;      /**< content freshness period */
 };
 
 struct ccnl_pkt_s {

--- a/src/ccnl-core/src/ccnl-content.c
+++ b/src/ccnl-core/src/ccnl-content.c
@@ -56,6 +56,13 @@ ccnl_content_new(struct ccnl_pkt_s **pkt)
     c->pkt = *pkt;
     *pkt = NULL;
     c->last_used = CCNL_NOW();
+#ifdef USE_SUITE_NDNTLV
+    if (c->pkt->suite == CCNL_SUITE_NDNTLV) {
+        /* convert from milli seconds to seconds for now, as CCNL_NOW() has second granularity */
+        c->freshnessperiod = CCNL_NOW() + (c->pkt->s.ndntlv.freshnessperiod / 1000);
+        c->stale = false;
+    }
+#endif
 
     return c;
 }

--- a/src/ccnl-core/src/ccnl-mgmt.c
+++ b/src/ccnl-core/src/ccnl-mgmt.c
@@ -189,7 +189,7 @@ ccnl_mgmt_send_return_split(struct ccnl_relay_s *ccnl, struct ccnl_buf_s *orig,
                 sprintf(uri, "/mgmt/seqnum-%d", it);
                 pkt = ccnl_calloc(1, sizeof(*pkt));
                 pkt->pfx = ccnl_URItoPrefix(uri, CCNL_SUITE_CCNB, NULL, NULL);
-                pkt->buf = ccnl_mkSimpleContent(pkt->pfx, buf2, len5, &contentpos);
+                pkt->buf = ccnl_mkSimpleContent(pkt->pfx, buf2, len5, &contentpos, NULL);
                 pkt->content = pkt->buf->data + contentpos;
                 pkt->contlen = len5;
                 c = ccnl_content_new(&pkt);

--- a/src/ccnl-fwd/src/ccnl-echo.c
+++ b/src/ccnl-fwd/src/ccnl-echo.c
@@ -62,7 +62,7 @@ ccnl_echo_request(struct ccnl_relay_s *relay, struct ccnl_face_s *inface,
     cp = ccnl_malloc(strlen(s) + 60);
     sprintf(cp, "%s\n%suptime %s\n", s, ctime(&t), timestamp());
 
-    reply = ccnl_mkSimpleContent(pfx, (unsigned char*) cp, strlen(cp), 0);
+    reply = ccnl_mkSimpleContent(pfx, (unsigned char*) cp, strlen(cp), 0, NULL);
     ccnl_free(cp);
     if (pfx2) {
         free_prefix(pfx2);

--- a/src/ccnl-nfn/src/ccnl-nfn-common.c
+++ b/src/ccnl-nfn/src/ccnl-nfn-common.c
@@ -144,7 +144,7 @@ ccnl_nfn_result2content(struct ccnl_relay_s *ccnl,
     if (!pkt)
         return NULL;
 
-    pkt->buf = ccnl_mkSimpleContent(*prefix, resultstr, resultlen, &resultpos);
+    pkt->buf = ccnl_mkSimpleContent(*prefix, resultstr, resultlen, &resultpos, NULL);
     if (!pkt->buf) {
         ccnl_free(pkt);
         return NULL;

--- a/src/ccnl-nfn/src/ccnl-nfn-requests.c
+++ b/src/ccnl-nfn/src/ccnl-nfn-requests.c
@@ -290,7 +290,7 @@ nfn_request_content_pkt_new(struct ccnl_prefix_s *pfx, unsigned char* payload, i
         break;
     }
     pkt->pfx = ccnl_prefix_dup(pfx);
-    pkt->buf = ccnl_mkSimpleContent(pkt->pfx, payload, paylen, &dataoffset);
+    pkt->buf = ccnl_mkSimpleContent(pkt->pfx, payload, paylen, &dataoffset, NULL);
     pkt->content = pkt->buf->data + dataoffset;
     pkt->contlen = paylen;
 
@@ -466,7 +466,7 @@ nfn_request_handle_interest(struct ccnl_relay_s *relay, struct ccnl_face_s *from
             DEBUGMSG_CFWD(DEBUG, "  is a keepalive interest\n");
             if (ccnl_nfn_already_computing(relay, (*pkt)->pfx)) {
                 DEBUGMSG_CFWD(DEBUG, "  running computation found");
-                struct ccnl_buf_s *buf = ccnl_mkSimpleContent((*pkt)->pfx, NULL, 0, NULL);
+                struct ccnl_buf_s *buf = ccnl_mkSimpleContent((*pkt)->pfx, NULL, 0, NULL, NULL);
                 ccnl_face_enqueue(relay, from, buf);
                 return 0;
             }
@@ -482,7 +482,7 @@ nfn_request_handle_interest(struct ccnl_relay_s *relay, struct ccnl_face_s *from
                 char reply[16];
                 snprintf(reply, 16, "%d", internum);
                 int size = internum >= 0 ? strlen(reply) : 0;
-                struct ccnl_buf_s *buf  = ccnl_mkSimpleContent((*pkt)->pfx, (unsigned char *)reply, size, &offset);
+                struct ccnl_buf_s *buf  = ccnl_mkSimpleContent((*pkt)->pfx, (unsigned char *)reply, size, &offset, NULL);
                 ccnl_face_enqueue(relay, from, buf);
                 return 0;
             }
@@ -595,7 +595,7 @@ nfn_request_RX_intermediate(struct ccnl_relay_s *relay, struct ccnl_face_s *from
     struct ccnl_pkt_s *packet;
     packet = ccnl_calloc(1, sizeof(*packet));
     packet->pfx = interm_pfx;
-    packet->buf = ccnl_mkSimpleContent(packet->pfx, (*pkt)->content, (*pkt)->contlen, &dataoffset);
+    packet->buf = ccnl_mkSimpleContent(packet->pfx, (*pkt)->content, (*pkt)->contlen, &dataoffset, NULL);
     packet->content = packet->buf->data + dataoffset;
     packet->contlen = (*pkt)->contlen;
 
@@ -638,7 +638,7 @@ nfn_request_RX_cancel(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     struct ccnl_pkt_s *packet;
     packet = ccnl_calloc(1, sizeof(*packet));
     packet->pfx = cancel_pfx;
-    packet->buf = ccnl_mkSimpleContent(packet->pfx, c->pkt->content, c->pkt->contlen, &dataoffset);
+    packet->buf = ccnl_mkSimpleContent(packet->pfx, c->pkt->content, c->pkt->contlen, &dataoffset, NULL);
     packet->content = packet->buf->data + dataoffset;
     packet->contlen = c->pkt->contlen;
 

--- a/src/ccnl-pkt/include/ccnl-pkt-builder.h
+++ b/src/ccnl-pkt/include/ccnl-pkt-builder.h
@@ -70,15 +70,17 @@ ccnl_isFragment(unsigned char *buf, int len, int suite);
 
 struct ccnl_content_s *
 ccnl_mkContentObject(struct ccnl_prefix_s *name,
-                     unsigned char *payload, int paylen);
+                     unsigned char *payload, int paylen,
+                     ccnl_data_opts_u *opts);
 
 struct ccnl_buf_s*
 ccnl_mkSimpleContent(struct ccnl_prefix_s *name,
-                     unsigned char *payload, int paylen, int *payoffset);
+                     unsigned char *payload, int paylen, int *payoffset,
+                     ccnl_data_opts_u *opts);
 
 void
 ccnl_mkContent(struct ccnl_prefix_s *name, unsigned char *payload, int paylen, unsigned char *tmp,
-               int *len, int *contentpos, int *offs);
+               int *len, int *contentpos, int *offs, ccnl_data_opts_u *opts);
 
 
 struct ccnl_interest_s *

--- a/src/ccnl-pkt/include/ccnl-pkt-ndntlv.h
+++ b/src/ccnl-pkt/include/ccnl-pkt-ndntlv.h
@@ -122,6 +122,17 @@ struct ccnl_ndntlv_interest_opts_s {
     uint32_t interestlifetime;  /**< Interest Lifetime Guider */
 };
 
+/**
+ * @brief NDN Data options
+ */
+struct ccnl_ndntlv_data_opts_s {
+    /* MetaInfo */
+    uint32_t freshnessperiod;       /**< freshness period */
+    /* FinalBlockID is actually from type NameComponent.
+     * Use integer for simplicity for now */
+    uint32_t finalblockid;          /**< final block ID */
+};
+
 #ifdef USE_SUITE_NDNTLV
 int
 ccnl_ndntlv_varlenint(unsigned char **buf, int *len, int *val);
@@ -148,7 +159,7 @@ ccnl_ndntlv_prependInterest(struct ccnl_prefix_s *name, int scope, struct ccnl_n
 int
 ccnl_ndntlv_prependContent(struct ccnl_prefix_s *name,
                            unsigned char *payload, int paylen,
-                           int *contentpos, unsigned int *final_block_id,
+                           int *contentpos, struct ccnl_ndntlv_data_opts_s *opts,
                            int *offset, unsigned char *buf);
 
 int

--- a/src/ccnl-pkt/src/ccnl-pkt-builder.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-builder.c
@@ -305,11 +305,12 @@ void ccnl_mkInterest(struct ccnl_prefix_s *name, ccnl_interest_opts_u *opts,
 
 struct ccnl_content_s *
 ccnl_mkContentObject(struct ccnl_prefix_s *name,
-                     unsigned char *payload, int paylen)
+                     unsigned char *payload, int paylen,
+                     ccnl_data_opts_u *opts)
 {
     int dataoffset;
     struct ccnl_pkt_s *c_p = ccnl_calloc(1, sizeof(struct ccnl_pkt_s));
-    c_p->buf = ccnl_mkSimpleContent(name, payload, paylen, &dataoffset);
+    c_p->buf = ccnl_mkSimpleContent(name, payload, paylen, &dataoffset, opts);
     c_p->pfx = ccnl_prefix_dup(name);
     c_p->content = c_p->buf->data + dataoffset;
     c_p->contlen = paylen;
@@ -319,7 +320,8 @@ ccnl_mkContentObject(struct ccnl_prefix_s *name,
 
 struct ccnl_buf_s*
 ccnl_mkSimpleContent(struct ccnl_prefix_s *name,
-                     unsigned char *payload, int paylen, int *payoffset)
+                     unsigned char *payload, int paylen, int *payoffset,
+                     ccnl_data_opts_u *opts)
 {
     struct ccnl_buf_s *buf = NULL;
     unsigned char *tmp;
@@ -336,7 +338,7 @@ ccnl_mkSimpleContent(struct ccnl_prefix_s *name,
     tmp = (unsigned char*) ccnl_malloc(CCNL_MAX_PACKET_SIZE);
     offs = CCNL_MAX_PACKET_SIZE;
 
-    ccnl_mkContent(name, payload, paylen, tmp, &len, &contentpos, &offs);
+    ccnl_mkContent(name, payload, paylen, tmp, &len, &contentpos, &offs, opts);
 
     if (len) {
         buf = ccnl_buf_new(tmp + offs, len);
@@ -350,7 +352,7 @@ ccnl_mkSimpleContent(struct ccnl_prefix_s *name,
 
 void
 ccnl_mkContent(struct ccnl_prefix_s *name, unsigned char *payload, int paylen, unsigned char *tmp,
-int *len, int *contentpos, int *offs) {
+               int *len, int *contentpos, int *offs, ccnl_data_opts_u *opts) {
     switch (name->suite) {
 #ifdef USE_SUITE_CCNB
         case CCNL_SUITE_CCNB:
@@ -388,7 +390,7 @@ int *len, int *contentpos, int *offs) {
 #ifdef USE_SUITE_NDNTLV
         case CCNL_SUITE_NDNTLV:
             (*len) = ccnl_ndntlv_prependContent(name, payload, paylen,
-                                                contentpos, NULL, offs, tmp);
+                                                contentpos, &(opts->ndntlv), offs, tmp);
             break;
 #endif
         default:

--- a/src/ccnl-utils/ccn-lite-mkC.c
+++ b/src/ccnl-utils/ccn-lite-mkC.c
@@ -51,12 +51,14 @@ main(int argc, char *argv[])
     struct key_s *keys = NULL;
     struct ccnl_prefix_s *prefix;
     struct ccnl_buf_s *buf;
+    ccnl_data_opts_u data_opts;
     (void)prefix;
     (void)buf;
     (void) contentpos;
     (void)keys;
     (void)lastchunknum;
     (void)chunknum;
+    (void) data_opts;
 
     while ((opt = getopt(argc, argv, "hg:i:k:l:n:o:p:s:v:w:")) != -1) {
         switch (opt) {
@@ -201,8 +203,9 @@ Usage:
                   lastchunknum == UINT_MAX ? NULL : &lastchunknum,
                   NULL, keyval, keyid, &offs, out);
         } else {
+            data_opts.ndntlv.finalblockid = lastchunknum;
             len = ccnl_ndntlv_prependContent(name, body, len,
-                  NULL, lastchunknum == UINT_MAX ? NULL : &lastchunknum,
+                  NULL, lastchunknum == UINT_MAX ? NULL : &(data_opts.ndntlv),
                   &offs, out);
         }
         break;

--- a/src/ccnl-utils/ccn-lite-produce.c
+++ b/src/ccnl-utils/ccn-lite-produce.c
@@ -39,6 +39,7 @@ main(int argc, char *argv[])
     int suite = CCNL_SUITE_CCNTLV;
     int chunk_size = CCNL_MAX_CHUNK_SIZE;
     struct ccnl_prefix_s *name;
+    ccnl_data_opts_u data_opts;
 
     while ((opt = getopt(argc, argv, "hc:f:i:o:p:k:w:s:v:")) != -1) {
         switch (opt) {
@@ -240,10 +241,11 @@ Usage:
             contentlen = CCNL_MAX_PACKET_SIZE - offs;
             break;
         case CCNL_SUITE_NDNTLV:
+            data_opts.ndntlv.finalblockid = lastchunknum;
             contentlen = ccnl_ndntlv_prependContent(name,
                                  (unsigned char *) chunk_buf, chunk_len,
                                  NULL,
-                                 &lastchunknum,// is_last ? &chunknum : NULL,
+                                 &(data_opts.ndntlv),// is_last ? &chunknum : NULL,
                                  &offs, out);
             break;
         default:


### PR DESCRIPTION
This patch introduces an options struct for Data messages. Along that change, I also included the option **freshnessperiod** for Data messages and **mustbefresh** for Interest messages. After **freshnessperiod** milli seconds, the content is marked as stale and **iff** an Interest message contains a **MustBeFresh** TLV, then stale content will be ignored.