### PR TITLE
ndntlv: remove unaligned memory access for cortex m0

### DIFF
--- a/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
@@ -51,11 +51,14 @@ ccnl_ndntlv_varlenint(unsigned char **buf, int *len, int *val)
         *buf += 1;
         *len -= 1;
     } else if (**buf == 253 && *len >= 3) { // 2 bytes
-        *val = ntohs(*(uint16_t*)(*buf + 1));
+        /* ORing bytes does not provoke alignment issues */
+        *val = ((*buf)[1] << 8) | ((*buf)[2] << 0);
         *buf += 3;
         *len -= 3;
     } else if (**buf == 254 && *len >= 5) { // 4 bytes
-        *val = ntohl(*(uint32_t*)(*buf + 1));
+        /* ORing bytes does not provoke alignment issues */
+        *val = ((*buf)[1] << 24) | ((*buf)[2] << 16) |
+               ((*buf)[3] <<  8) | ((*buf)[4] <<  0);
         *buf += 5;
         *len -= 5;
     } else {


### PR DESCRIPTION
Cortex m0 does not support unaligned memory access. When compiling (with RIOT) for a cortex m0+ architecture, the compiler generates an [LDRH](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka15414.html) statement with an unaligned address to load. This stems from the fact, that a lower type pointer (`uint8_t *`) is casted to a higher type pointer (`uint16_t *`).

Concatenating the bytes as I proposed in this patch is safe w.r.t. alignment and makes the call to `ntohs` obsolete.