### PR TITLE
ccn-lite-ctrl: fix parsing of UDP string

### DIFF
--- a/src/ccnl-utils/ccn-lite-ctrl.c
+++ b/src/ccnl-utils/ccn-lite-ctrl.c
@@ -1094,7 +1094,8 @@ main(int argc, char *argv[])
             break;
         case 'u':
             udp = strdup(optarg);
-            port = strtol(strtok(udp, "/"), NULL, 0);
+            udp = strtok(udp, "/");
+            port = strtol(strtok(NULL, "/"), NULL, 0);
             use_udp = 1;
 printf("udp: <%s> <%d>\n", udp, port);
             break;


### PR DESCRIPTION
In the current version the `ccn-lite-ctrl` command tries to send to the
port equal to the first byte of the given IP address when used with
`-u`.

Calling `strtok()` with the first parameter `!= NULL` returns the
*first* token of a tokenized string. Subsequent tokens are retrieved
with a subsequent call of `strtok` with the first parameter being
`NULL`.

This commit sets the result of `strtok()` to `udp` (the IP address
string in the later program) and uses the subsequent call with `NULL`
to parse the UDP port.