### PR TITLE
riot: provide multi-interface support

### DIFF
--- a/src/ccnl-core/include/ccnl-defs.h
+++ b/src/ccnl-core/include/ccnl-defs.h
@@ -37,7 +37,12 @@
 #define CCNL_BROADCAST_OCTET            0xFF
 
 #if defined(CCNL_ARDUINO) || defined(CCNL_RIOT)
-# define CCNL_MAX_INTERFACES             1
+# if defined(CCNL_RIOT)
+#  include "net/gnrc/netif.h"
+#  define CCNL_MAX_INTERFACES            GNRC_NETIF_NUMOF
+# else
+#  define CCNL_MAX_INTERFACES            1
+# endif
 # define CCNL_MAX_IF_QLEN                14
 #ifndef CCNL_MAX_PACKET_SIZE
 # define CCNL_MAX_PACKET_SIZE            120

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -231,10 +231,13 @@ ccnl_open_netif(kernel_pid_t if_pid, gnrc_nettype_t netreg_type)
 
     /* configure the interface to use the specified nettype protocol */
     gnrc_netapi_set(if_pid, NETOPT_PROTO, 0, &netreg_type, sizeof(gnrc_nettype_t));
-    /* register for this nettype */
-    gnrc_netreg_entry_init_pid(&_ccnl_ne, GNRC_NETREG_DEMUX_CTX_ALL,
-                               _ccnl_event_loop_pid);
-    return gnrc_netreg_register(netreg_type, &_ccnl_ne);
+    /* register for this nettype if not already done */
+    if (_ccnl_ne.demux_ctx == 0) {
+        gnrc_netreg_entry_init_pid(&_ccnl_ne, GNRC_NETREG_DEMUX_CTX_ALL,
+                                   _ccnl_event_loop_pid);
+        return gnrc_netreg_register(netreg_type, &_ccnl_ne);
+    }
+    return 0;
 }
 
 static msg_t _ageing_reset = { .type = CCNL_MSG_AGEING };


### PR DESCRIPTION
Provides multi-interface support for CCN-lite.

For the future it might be a good idea to split up interface and stack initialization so an end-less loop like it happened before this patch when trying to register multiple interfaces can't happen.