### PR TITLE
ccnl-relay: check if face ifndx matches given ifndx

### DIFF
--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -55,7 +55,8 @@ ccnl_get_face_or_create(struct ccnl_relay_s *ccnl, int ifndx,
                 return f;
             continue;
         }
-        if (ifndx != -1 && !ccnl_addr_cmp(&f->peer, (sockunion*)sa)) {
+        if (ifndx != -1 && (f->ifndx == ifndx) &&
+            !ccnl_addr_cmp(&f->peer, (sockunion*)sa)) {
             f->last_used = CCNL_NOW();
             return f;
         }


### PR DESCRIPTION
Not really sure this is correct, but I have the situation where I have
2 `AF_PACKET` interfaces in use with RONR and CCN-lite is only
broadcasting out one of the interfaces. This is happening, because both
interfaces get the same broadcast `sockaddr` down in 471-477, so `sa`
is matching at the fixed line with `f->peer` of the first interface a
broadcast face was created for.

This fixes the problem for me, but where I'm not sure is how other face
types might be affected by this change.