### PR TITLE
some memsantization

### DIFF
--- a/src/ccnl-unix/src/ccnl-unix.c
+++ b/src/ccnl-unix/src/ccnl-unix.c
@@ -430,6 +430,7 @@ ccnl_relay_config(struct ccnl_relay_s *relay, char *ethdev, char *wpandev,
 
     relay->contents = NULL;
     relay->pit = NULL;
+    relay->fib = NULL;
     relay->faces = NULL;
     relay->nonces = NULL;
     relay->max_cache_entries = max_cache_entries;


### PR DESCRIPTION
this patch set some default values to avoid out of bound memory access (which is clearly not a vulnerability but a bug!)