### PR TITLE
add better definition for ndn timeout

### DIFF
--- a/src/ccnl-pkt/include/ccnl-pkt-ndntlv.h
+++ b/src/ccnl-pkt/include/ccnl-pkt-ndntlv.h
@@ -28,6 +28,14 @@
 
 #include "ccnl-content.h"
 
+/**
+ * Default interest lifetime in milliseconds. If the element is omitted by a user, a default
+ * value of 4 seconds is used.
+ */
+#ifndef NDN_DEFAULT_INTEREST_LIFETIME
+#define NDN_DEFAULT_INTEREST_LIFETIME (4000u)
+#endif
+
 #define NDN_UDP_PORT                    6363
 #define NDN_DEFAULT_MTU                 4096
 

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -549,7 +549,7 @@ ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, int buf_len
     ccnl_interest_opts_u default_opts;
     default_opts.ndntlv.nonce = 0;
     default_opts.ndntlv.mustbefresh = false;
-    default_opts.ndntlv.interestlifetime = CCNL_INTEREST_TIMEOUT;
+    default_opts.ndntlv.interestlifetime = NDN_DEFAULT_INTEREST_LIFETIME;
 
     if (_ccnl_suite != CCNL_SUITE_NDNTLV) {
         DEBUGMSG(WARNING, "Suite not supported by RIOT!");


### PR DESCRIPTION
address discussion in PR #209 and #214.

Further changes in NDN should be discussed, where to use "NDN_DEFAULT_INTEREST_LIFETIME"