### PR TITLE
ccnl-relay/ccnl_cs_dump: print correct string length

### DIFF
--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -1033,10 +1033,10 @@ ccnl_cs_dump(struct ccnl_relay_s *ccnl)
     (void) s;
 
     while (c) {
-        printf("CS[%u]: %s [%d]: %s\n", i++,
+        printf("CS[%u]: %s [%d]: %.*s\n", i++,
                ccnl_prefix_to_str(c->pkt->pfx,s,CCNL_MAX_PREFIX_SIZE),
                (c->pkt->pfx->chunknum)? *(c->pkt->pfx->chunknum) : -1,
-               c->pkt->content);
+               c->pkt->contlen, c->pkt->content);
         c = c->next;
     }
 #endif


### PR DESCRIPTION
Define length of the string to print in CS dump function.