### PR TITLE
ccn-lite-riot: remove duplicate random_init()

### DIFF
--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -415,10 +415,6 @@ void
     msg_init_queue(_msg_queue, CCNL_QUEUE_SIZE);
     struct ccnl_relay_s *ccnl = (struct ccnl_relay_s*) arg;
 
-
-    /* XXX: https://xkcd.com/221/ */
-    random_init(0x4);
-
     while(!ccnl->halt_flag) {
         msg_t m, reply;
         /* start periodic timer */


### PR DESCRIPTION
This PR removes (the **static**) PRNG- reinitialization in the RIOT adapter. I think it is a leftover from former days when the PRNG wasn't seeded by `auto_init()` in RIOT. Nowadays this is done [here](https://github.com/RIOT-OS/RIOT/blob/master/sys/random/random.c#L30).