### PR TITLE
ccn-lite-riot: avoid ageing_timer reset with each l2 sending

### DIFF
--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -250,10 +250,6 @@ ccnl_ll_TX(struct ccnl_relay_s *ccnl, struct ccnl_if_s *ifc,
     (void) ccnl;
     int rc;
     DEBUGMSG(TRACE, "ccnl_ll_TX %d bytes to %s\n", (int)(buf ? buf->datalen : -1), ccnl_addr2ascii(dest));
-    /* reset ageing timer */
-    xtimer_remove(&_ageing_timer);
-    xtimer_set_msg(&_ageing_timer, US_PER_SEC, &_ageing_reset, _ccnl_event_loop_pid);
-    DEBUGMSG(TRACE, "ccnl_ll_TX: reset timer\n");
 
     (void) ifc;
     switch(dest->sa.sa_family) {
@@ -415,9 +411,11 @@ void
     msg_init_queue(_msg_queue, CCNL_QUEUE_SIZE);
     struct ccnl_relay_s *ccnl = (struct ccnl_relay_s*) arg;
 
+    /* start periodic timer */
+    xtimer_set_msg(&_ageing_timer, US_PER_SEC, &_ageing_reset, sched_active_pid);
+
     while(!ccnl->halt_flag) {
         msg_t m, reply;
-        /* start periodic timer */
         reply.type = CCNL_MSG_AGEING;
         DEBUGMSG(VERBOSE, "ccn-lite: waiting for incoming message.\n");
         msg_receive(&m);


### PR DESCRIPTION
The  `ccnl_do_aging()` function is assumed to be called once in a second to take care of the PIT, CS, retransmissions, ... In the RIOT adapter, each packet to send (via `ccnl_ll_TX´) resets the ageing timer which calls the ageing function, and sets it again to one second.  Assuming there are multiple packets to be send within one second, this timer resets regularly and prevents from calling the function temporarily. To avoid that, we call the function regularly.

Relates to #225.