### PR TITLE
make some defines configurable

### DIFF
--- a/src/ccnl-core/include/ccnl-defs.h
+++ b/src/ccnl-core/include/ccnl-defs.h
@@ -71,12 +71,20 @@
 # define CCNL_DEFAULT_MAX_PIT_ENTRIES    (-1)
 #endif
 
-#define CCNL_CONTENT_TIMEOUT            300 // sec
-#define CCNL_INTEREST_TIMEOUT           10  // sec
-#define CCNL_MAX_INTEREST_RETRANSMIT    7
+#ifndef CCNL_CONTENT_TIMEOUT
+# define CCNL_CONTENT_TIMEOUT            300 // sec
+#endif
+#ifndef CCNL_INTEREST_TIMEOUT
+# define CCNL_INTEREST_TIMEOUT           10  // sec
+#endif
+#ifndef CCNL_MAX_INTEREST_RETRANSMIT
+# define CCNL_MAX_INTEREST_RETRANSMIT    7
+#endif
 
-// #define CCNL_FACE_TIMEOUT    60 // sec
-#define CCNL_FACE_TIMEOUT       30 // sec
+#ifndef CCNL_FACE_TIMEOUT
+// # define CCNL_FACE_TIMEOUT    60 // sec
+# define CCNL_FACE_TIMEOUT       30 // sec
+#endif
 
 #define CCNL_DEFAULT_MAX_CACHE_ENTRIES  0   // means: no content caching
 #ifdef CCNL_RIOT

--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -57,12 +57,16 @@ extern "C" {
 /**
  * Stack size for CCN-Lite event loop
  */
+#ifndef CCNL_STACK_SIZE
 #define CCNL_STACK_SIZE (THREAD_STACKSIZE_MAIN)
+#endif
 
 /**
  * Size of the message queue of CCN-Lite's event loop
  */
+#ifndef CCNL_QUEUE_SIZE
 #define CCNL_QUEUE_SIZE     (8)
+#endif
 
 /**
  * @brief Data structure for interest packet


### PR DESCRIPTION
This PR allows to overwrite basic CCN-lite definitions as well as RIOT thread specific parameters