### PR TITLE
removes ccnl_addr2ascii calls in DEBUGMSG macros containing NULL

### DIFF
--- a/src/ccnl-core/include/ccnl-sockunion.h
+++ b/src/ccnl-core/include/ccnl-sockunion.h
@@ -111,8 +111,21 @@ typedef union {
 int
 ccnl_is_local_addr(sockunion *su);
 
-char*
-ccnl_addr2ascii(sockunion *su);
+/**
+ * @brief Returns a string representation of a given socket
+ *
+ * This function checks if the given socket type is supported by CCN-lite and
+ * returns its string representation. In no circumstance should one pass this
+ * function without a check to the return type to a function expecting a
+ * string, e.g. "printf("from: %s\n", ccnl_addr2ascii(some_type));"!
+ *
+ * @param[in] su The socket type to represent as string
+ *
+ * @return NULL if \ref su was NULL
+ * @return NULL if the given socket type is not supported
+ * @return A string representation of \ref su
+ */
+char* ccnl_addr2ascii(sockunion *su);
 
 int
 ccnl_addr_cmp(sockunion *s1, sockunion *s2);

--- a/src/ccnl-fwd/src/ccnl-fwd.c
+++ b/src/ccnl-fwd/src/ccnl-fwd.c
@@ -70,17 +70,36 @@ ccnl_fwd_handleContent(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
         }
     }
 
-    DEBUGMSG_CFWD(INFO, "  incoming data=<%s>%s (nfnflags=%d) nonce=%i from=%s\n",
-                  ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE),
-                  ccnl_suite2str((*pkt)->suite),
-                  (*pkt)->pfx->nfnflags, nonce,
-                  ccnl_addr2ascii(from ? &from->peer : NULL));
+    if (from) {
+        char *from_as_str = ccnl_addr2ascii(&(from->peer));
+
+        if (from_as_str) {
+            DEBUGMSG_CFWD(INFO, "  incoming data=<%s>%s (nfnflags=%d) nonce=%i from=%s\n",
+                ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE), ccnl_suite2str((*pkt)->suite),
+                (*pkt)->pfx->nfnflags, nonce, from_as_str ? from_as_str : "");
+        } 
+    } else {
+        DEBUGMSG_CFWD(INFO, "  incoming data=<%s>%s (nfnflags=%d) nonce=%i from=%s\n",
+            ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE), ccnl_suite2str((*pkt)->suite),
+            (*pkt)->pfx->nfnflags, nonce, "");
+
+    }
+
     DEBUGMSG_CFWD(INFO, "  data %.*s\n", (*pkt)->contlen, (*pkt)->content);
 #else
-    DEBUGMSG_CFWD(INFO, "  incoming data=<%s>%s from=%s\n",
-                  ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE),
-                  ccnl_suite2str((*pkt)->suite),
-                  ccnl_addr2ascii(from ? &from->peer : NULL));
+    if (from) {
+        char *from_as_str = ccnl_addr2ascii(&(from->peer));
+
+        if (from_as_str) {
+             DEBUGMSG_CFWD(INFO, "  incoming data=<%s>%s from=%s\n",
+                ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE), ccnl_suite2str((*pkt)->suite),
+                  from_as_str ? from_as_str : "");
+        }
+    } else {
+        DEBUGMSG_CFWD(INFO, "  incoming data=<%s>%s from=%s\n",
+            ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE), ccnl_suite2str((*pkt)->suite), "");
+
+    }
 #endif
 
 #if defined(USE_SUITE_CCNB) && defined(USE_SIGNATURES)
@@ -183,9 +202,12 @@ ccnl_fwd_handleFragment(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     unsigned char *data = (*pkt)->content;
     int datalen = (*pkt)->contlen;
 
-    DEBUGMSG_CFWD(INFO, "  incoming fragment (%zd bytes) from=%s\n",
-                  (*pkt)->buf->datalen,
-                  ccnl_addr2ascii(from ? &from->peer : NULL));
+    if (from) {
+        char *from_as_str = ccnl_addr2ascii(&(from->peer));
+
+        DEBUGMSG_CFWD(INFO, "  incoming fragment (%zd bytes) from=%s\n", 
+            (*pkt)->buf->datalen, from_as_str ? from_as_str : "");
+    }
 
     ccnl_frag_RX_BeginEnd2015(callback, relay, from,
                               relay->ifs[from->ifndx].mtu,
@@ -231,18 +253,20 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
         }
     }
 
-
+    if (from) {
+        char *from_as_str = ccnl_addr2ascii(&(from->peer));
 #ifndef CCNL_LINUXKERNEL
-    DEBUGMSG_CFWD(INFO, "  incoming interest=<%s>%s nonce=%"PRIi32" from=%s\n",
-                  ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE),
-                  ccnl_suite2str((*pkt)->suite), nonce,
-                  ccnl_addr2ascii(from ? &from->peer : NULL));
+        DEBUGMSG_CFWD(INFO, "  incoming interest=<%s>%s nonce=%"PRIi32" from=%s\n",
+             ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE),
+             ccnl_suite2str((*pkt)->suite), nonce,
+             from_as_str ? from_as_str : "");
 #else
-    DEBUGMSG_CFWD(INFO, "  incoming interest=<%s>%s nonce=%d from=%s\n",
-                  ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE),
-                  ccnl_suite2str((*pkt)->suite), nonce,
-                  ccnl_addr2ascii(from ? &from->peer : NULL));
+        DEBUGMSG_CFWD(INFO, "  incoming interest=<%s>%s nonce=%d from=%s\n",
+            ccnl_prefix_to_str((*pkt)->pfx,s,CCNL_MAX_PREFIX_SIZE),
+            ccnl_suite2str((*pkt)->suite), nonce,
+            from_as_str ? from_as_str : "");
 #endif
+    }
 
 #ifdef USE_DUP_CHECK
 


### PR DESCRIPTION
This PR addresses (partially) #232 and removes ``ccnl_addr2ascii`` calls in ``ccnl-fwd.c`` which might have NULL as a parameter as a result of the evaluation of an ternary operator, i.e.
```C
ccnl_addr2ascii(from ? &from->peer : NULL)
```
In order to test this PR, the ``USE_LOGGING`` flag needs to be set. In addition, logging needs to be enabled in the ``ccn-lite-relay`` example by setting ``debug_level = VERBOSE;``.