### PR TITLE
created a short version of development procedures

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# CONTRIBUTE
+This is a short version of the [Development Procedures](https://github.com/cn-uofbasel/ccn-lite/wiki/Development-procedures).
+
+1. Check if your code follows the [coding conventions](https://github.com/cn-uofbasel/ccn-lite/wiki/Coding-conventions). If the code does not comply these style rules, your code will not be merged.
+
+2. The master branch should always be in a working state. The CCN-lite maintainers will create release tags based on this branch, whenever a milestone is completed.
+
+3. Comments on a pull request should be added to the request itself, and *not* to the commit.
+
+4. Keep commits to the point, e.g., don't add whitespace/typo fixes to other code changes. If changes are layered, layer the patches.
+
+5. Describe the technical detail of the change(s) as specific as possible.
+
+6. Use [Labels](https://github.com/cn-uofbasel/ccn-lite/wiki/Labels) to help classify pull requests and issues.


### PR DESCRIPTION
This file provides a short version of our development procedures (still work in progress) and allow to set contributing guidelines for the project. You can set the guidelines via Insights -> Community

This document is a shameless adaption of [RIOTs contributing guidelines](https://github.com/RIOT-OS/RIOT/blob/master/CONTRIBUTING.md).

This PR is part of our discussion in #221

Further information can be found [here](https://help.github.com/articles/setting-guidelines-for-repository-contributors/) (githubs setting guidelines for repository contributors).