### PR TITLE
provides templates for PRs and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,30 @@
+#### Description
+<!--
+Example: Cannot build CCN-lite for RIOT.
+-->
+
+#### Steps to reproduce the issue
+<!--
+Try to describe as precisely as possible here the steps required to reproduce
+the issue. Here you can also describe your hardware configuration, the network
+setup, etc.
+-->
+
+#### Expected results
+<!--
+Example: CCN-lite builds for RIOT.
+-->
+
+#### Actual results
+<!--
+Please paste or specifically describe the actual output.
+-->
+
+#### Versions
+<!--
+Operating system: Mac OSX, Linux, Vagrant VM
+Build environment: GCC, CLang versions, etc.
+-->
+
+<!-- Thanks for contributing! -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!--
+Before describing what your contribution is about, we would like
+you to make sure that your modifications are compliant with the CCN-lite
+coding conventions, see https://github.com/cn-uofbasel/ccn-lite/wiki/Coding-conventions.
+-->
+
+### Contribution description
+
+<!--
+Put here the description of your contribution:
+- describe which part(s) of CCN-lite is (are) involved
+- if it's a bug fix, describe the bug that it solves and how it is solved
+- you can also give more information to reviewers about how to test your changes
+-->
+
+
+### Issues/PRs references
+
+<!--
+Examples: Fixes #1234. See also #5678. Depends on PR #9876.
+
+Please use keywords (e.g., fixes, resolve) with the links to the issues you
+resolved, this way they will be automatically closed when your pull request
+is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
+-->


### PR DESCRIPTION
This PR provides templates for both, issues and pull requests. The templates are shamefully stolen from RIOT and slightly modified.  You can set the templates via Insights -> Community

This PR is part of our discussion in #221.