### PR TITLE
ccnl_content: function to add content to CS and check PIT

### DIFF
--- a/src/ccnl-core/include/ccnl-relay.h
+++ b/src/ccnl-core/include/ccnl-relay.h
@@ -239,5 +239,17 @@ ccnl_interface_CTS(void *aux1, void *aux2);
 int ccnl_app_RX(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c);
 #endif
 
+/**
+ * @brief Add content @p c to the Content Store and serve pending Interests
+ *
+ * @param[in] ccnl  pointer to current ccnl relay
+ * @param[in] c     content to add to the content store
+ *
+ * @return   0,  if @p c was added to the content store
+ * @return   -1, otherwise
+*/
+int
+ccnl_cs_add(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c);
+
 #endif //CCNL_RELAY_H
 /** @} */

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -1056,3 +1056,17 @@ ccnl_interface_CTS(void *aux1, void *aux2)
 #endif
     ccnl_free(req.buf);
 }
+
+int
+ccnl_cs_add(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
+{
+    struct ccnl_content_s *content;
+
+    content = ccnl_content_add2cache(ccnl, c);
+    if (content) {
+        ccnl_content_serve_pending(ccnl, content);
+        return 0;
+    }
+
+    return -1;
+}


### PR DESCRIPTION
### Contribution description

CCN-lite currently does not satisfy open PIT entries, when a content is added to the local cache by an application. An application usually calls the `_add2cache()` function, which completely bypasses the PIT.

This PR provides a function that should be used by applications instead of the `_add2cache()` function. The new function (`ccnl_cs_add()`) serves pending Interests after inserting the content into the cache.

### Issues/PRs references
none
