### PR TITLE
renamed free_prefix to ccnl_prefix_free

### DIFF
--- a/src/ccn-lite-simu.c
+++ b/src/ccn-lite-simu.c
@@ -191,7 +191,7 @@ ccnl_client_TX(char node, char *name, int seqn, int nonce)
 
     DEBUGMSG(TRACE, "  create interest for %s\n", ccnl_prefix_to_path(p));
     buf = ccnl_mkSimpleInterest(p, &opts);
-    free_prefix(p);
+    ccnl_prefix_free(p);
 
     // inject it into the relay:
     if (buf) {

--- a/src/ccnl-core/src/ccnl-mgmt.c
+++ b/src/ccnl-core/src/ccnl-mgmt.c
@@ -261,7 +261,7 @@ ccnl_prefix_clone(struct ccnl_prefix_s *p)
     }
     return p2;
 Bail:
-    free_prefix(p2);
+    ccnl_prefix_free(p2);
     return NULL;
 }
 */
@@ -1661,7 +1661,7 @@ Bail:
 
     ccnl_free(suite);
     ccnl_free(action);
-    free_prefix(p);
+    ccnl_prefix_free(p);
 
     //ccnl_mgmt_return_msg(ccnl, orig, from, cp);
     return rc;
@@ -1929,7 +1929,7 @@ ccnl_mgmt_addcacheobject(struct ccnl_relay_s *ccnl, struct ccnl_buf_s *orig,
         //Send interest to from!
         ccnl_face_enqueue(ccnl, from, buffer);
     }
-//    free_prefix(prefix_new);
+//    ccnl_prefix_free(prefix_new);
 
 Bail:
     return 0;

--- a/src/ccnl-fwd/src/ccnl-echo.c
+++ b/src/ccnl-fwd/src/ccnl-echo.c
@@ -65,7 +65,7 @@ ccnl_echo_request(struct ccnl_relay_s *relay, struct ccnl_face_s *inface,
     reply = ccnl_mkSimpleContent(pfx, (unsigned char*) cp, strlen(cp), 0, NULL);
     ccnl_free(cp);
     if (pfx2) {
-        free_prefix(pfx2);
+        ccnl_prefix_free(pfx2);
     }
 
     ucp = reply->data;
@@ -94,7 +94,7 @@ ccnl_echo_cleanup(struct ccnl_relay_s *relay)
             fwd->tap = NULL;
 /*
             if (fwd->face == NULL) { // remove this entry
-                free_prefix(fwd->prefix);
+                ccnl_prefix_free(fwd->prefix);
                 fwd->prefix = 0;
             }
 */


### PR DESCRIPTION
### Contribution description

Renames ``free_prefix`` to ``ccnl_prefix_free`` in files ``src/ccnl-fwd/src/ccnl-echo.c``, ``src/ccnl-core/src/ccnl-mgmt.c``, and  ``src/ccn-lite-simu.c``

### Issues/PRs references

 Fixes #244 