### PR TITLE
cmake: don't build unused TLV fomats for RIOT

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,12 +55,20 @@ add_definitions(${CCNL_PLATFORM_FLAGS})
 # Packet formats
 set(CCNL_PACKETFORMAT_FLAGS
     -DUSE_SUITE_NDNTLV
-    -DUSE_SUITE_CCNB
-    -DUSE_SUITE_CCNTLV
-    -DUSE_SUITE_LOCALRPC
     CACHE PATH
     "packet format flags for CCN-lite"
 )
+if (NOT DEFINED CCNL_RIOT)
+    set(CCNL_PACKETFORMAT_FLAGS
+        "${CCNL_PACKETFORMAT_FLAGS}"
+        -DUSE_SUITE_CCNB
+        -DUSE_SUITE_CCNTLV
+        -DUSE_SUITE_LOCALRPC
+        CACHE PATH
+        "packet format flags for CCN-lite"
+        FORCE
+    )
+endif()
 add_definitions(${CCNL_PACKETFORMAT_FLAGS})
 
 # NFN flags

--- a/src/ccnl-pkt/src/ccnl-pkt-builder.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-builder.c
@@ -119,6 +119,9 @@ ccnl_isContent(unsigned char *buf, int len, int suite)
 int
 ccnl_isFragment(unsigned char *buf, int len, int suite)
 {
+    (void) buf;
+    (void) len;
+
     switch(suite) {
 #ifdef USE_SUITE_CCNTLV
     case CCNL_SUITE_CCNTLV:


### PR DESCRIPTION
### Contribution description
This patch removes all TLV formats but the NDN TLV from building for RIOT. I discovered that although CCN and the others were not used by RIOT, they still ended up in the ROM section of the binary.

I had to `void` `buf` and `len` in `ccnl_isFragment()` to soothe the compiler.

### Issues/PRs references
None
