### PR TITLE
ccnl-riot: make thread prio configurable

### DIFF
--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -103,6 +103,10 @@ typedef struct {
 #define CCNL_CACHE_SIZE
 #endif
 
+#ifndef CCNL_THREAD_PRIORITY
+#define CCNL_THREAD_PRIORITY (THREAD_PRIORITY_MAIN - 1)
+#endif
+
 /**
  * Struct holding CCN-Lite's central relay information
  */

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -473,7 +473,7 @@ ccnl_start(void)
 
     /* start the CCN-Lite event-loop */
     _ccnl_event_loop_pid =  thread_create(_ccnl_stack, sizeof(_ccnl_stack),
-                                          THREAD_PRIORITY_MAIN - 1,
+                                          CCNL_THREAD_PRIORITY,
                                           THREAD_CREATE_STACKTEST, _ccnl_event_loop,
                                           &ccnl_relay, "ccnl");
     return _ccnl_event_loop_pid;


### PR DESCRIPTION
### Contribution description
Makes the RIOT thread priority for CCN-lite configurable on compile-time.


### Issues/PRs references
none