### PR TITLE
ccnl-riot: new line for debugmsg

### DIFF
--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -546,7 +546,7 @@ ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, int buf_len
     default_opts.ndntlv.interestlifetime = NDN_DEFAULT_INTEREST_LIFETIME;
 
     if (_ccnl_suite != CCNL_SUITE_NDNTLV) {
-        DEBUGMSG(WARNING, "Suite not supported by RIOT!");
+        DEBUGMSG(WARNING, "Suite not supported by RIOT!\n");
         return ret;
     }
 


### PR DESCRIPTION
### Contribution description
This patch adds a missing new line for a debug output in the RIOT adapter.


### Issues/PRs references
none