### PR TITLE
ccnl-riot: exit early on error for ccnl_send_interest()

### DIFF
--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -165,7 +165,10 @@ int ccnl_open_netif(kernel_pid_t if_pid, gnrc_nettype_t netreg_type);
  * @param[in] int_opts  Interest options (@ref ccnl_interest_opts_u)
  *
  * @return 0 on success
- * @return -1 on failure
+ * @return -1, packet format not supported
+ * @return -2, prefix is NULL
+ * @return -3, packet deheading failed
+ * @return -4, parsing failed
  */
 int ccnl_send_interest(struct ccnl_prefix_s *prefix,
                        unsigned char *buf, int buf_len,

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -586,6 +586,11 @@ ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, int buf_len
 
     pkt = ccnl_ndntlv_bytes2pkt(NDN_TLV_Interest, start, &data, &len);
 
+    if (!pkt) {
+        DEBUGMSG(WARNING, "could not create Interest pkt\n");
+        return -1;
+    }
+
     msg_t m = { .type = GNRC_NETAPI_MSG_TYPE_SND, .content.ptr = pkt };
     ret = msg_send(&m, _ccnl_event_loop_pid);
     if(ret < 1){

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -537,7 +537,7 @@ int
 ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, int buf_len,
                    ccnl_interest_opts_u *int_opts)
 {
-    int ret = -1;
+    int ret = 0;
     int len = 0;
     ccnl_interest_opts_u default_opts;
     default_opts.ndntlv.nonce = 0;
@@ -546,14 +546,14 @@ ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, int buf_len
 
     if (_ccnl_suite != CCNL_SUITE_NDNTLV) {
         DEBUGMSG(WARNING, "Suite not supported by RIOT!\n");
-        return ret;
+        return -1;
     }
 
     DEBUGMSG(INFO, "interest for chunk number: %u\n", (prefix->chunknum == NULL) ? 0 : *prefix->chunknum);
 
     if (!prefix) {
         DEBUGMSG(ERROR, "prefix could not be created!\n");
-        return ret;
+        return -2;
     }
 
     if (!int_opts) {
@@ -581,14 +581,14 @@ ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, int buf_len
     /* TODO: support other suites */
     if (ccnl_ndntlv_dehead(&data, &len, (int*) &typ, &int_len) || (int) int_len > len) {
         DEBUGMSG(WARNING, "  invalid packet format\n");
-        return ret;
+        return -3;
     }
 
     pkt = ccnl_ndntlv_bytes2pkt(NDN_TLV_Interest, start, &data, &len);
 
     if (!pkt) {
         DEBUGMSG(WARNING, "could not create Interest pkt\n");
-        return -1;
+        return -4;
     }
 
     msg_t m = { .type = GNRC_NETAPI_MSG_TYPE_SND, .content.ptr = pkt };


### PR DESCRIPTION
### Contribution description

Exit early in `ccnl_send_interest()` for the case, where `pkt` could not be created (e.g., when malloc fails due to low mem). Otherweise, `pkt` is `NULL` and accessed in subsequent functions.

### Issues/PRs references
none
