### PR TITLE
ccnl-fwd: do not set *pkt = NULL for local_producer

### DIFF
--- a/src/ccnl-fwd/src/ccnl-fwd.c
+++ b/src/ccnl-fwd/src/ccnl-fwd.c
@@ -280,7 +280,6 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     }
 #endif
     if (local_producer(relay, from, *pkt)) {
-        *pkt = NULL;
         return 0;
     }
 #if defined(USE_SUITE_CCNB) && defined(USE_MGMT)


### PR DESCRIPTION
### Contribution description
The `pkt` passed to `ccnl_fwd_handleInterest()` is freed after the invocation of `ccnl_fwd_handleInterest()`. However, setting `*pkt` to `NULL` in the `local_producer()` code path yields mem leaks and segfaults, because `NULL` is tried to be freed.

### Issues/PRs references
none