### PR TITLE
gcc: suppress empty translation unit errors

### DIFF
--- a/src/ccnl-fwd/src/ccnl-localrpc.c
+++ b/src/ccnl-fwd/src/ccnl-localrpc.c
@@ -634,4 +634,7 @@ ccnl_localrpc_exec(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
 
 #endif //USE_SUITE_LOCALRPC
 
+/* suppress empty translation unit error */
+typedef int unused_typedef;
+
 // eof

--- a/src/ccnl-pkt/src/ccnl-pkt-ccnb.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ccnb.c
@@ -483,4 +483,7 @@ ccnl_ccnb_fillContent(struct ccnl_prefix_s *name, unsigned char *data,
 
 #endif // USE_SUITE_CCNB
 
+/* suppress empty translation unit error */
+typedef int unused_typedef;
+
 // eof

--- a/src/ccnl-pkt/src/ccnl-pkt-ccntlv.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ccntlv.c
@@ -633,4 +633,7 @@ ccnl_ccntlv_mkFrag(struct ccnl_frag_s *fr, unsigned int *consumed)
 
 #endif // USE_SUITE_CCNTLV
 
+/* suppress empty translation unit error */
+typedef int unused_typedef;
+
 // eof

--- a/src/ccnl-pkt/src/ccnl-pkt-localrpc.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-localrpc.c
@@ -639,4 +639,7 @@ int ccnl_rdr_serialize(struct rdr_ds_s *ds, unsigned char *buf, int buflen)
 
 #endif // USE_SUITE_LOCALRPC
 
+/* suppress empty translation unit error */
+typedef int unused_typedef;
+
 // eof


### PR DESCRIPTION
### Contribution description
When omitting TLV formats other than NDN (for RIOT), then gcc complains about empty translation units. There are two solutions for that: 1) either put a dummy `typedef` into the translation unit, or 2) change the buildsystem to not even consider the `*.c` files.

I went with 1) to avoid touching the build system. Selectively considering `*.c` files depending on build flags will bloat the CMake files.

### Issues/PRs references
none