### PR TITLE
ccnl-riot: remove from CS in ccnl thread context 

### DIFF
--- a/src/ccnl-core/include/ccnl-relay.h
+++ b/src/ccnl-core/include/ccnl-relay.h
@@ -262,5 +262,19 @@ int ccnl_app_RX(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c);
 int
 ccnl_cs_add(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c);
 
+/**
+ * @brief Remove content with @p prefix from the Content Store
+ *
+ * @param[in] ccnl      pointer to current ccnl relay
+ * @param[in] prefix    prefix of the content to remove from the Content Store
+ *
+ * @return    0, if content with @p prefix was removed
+ * @return   -1, if @p ccnl or @p prefix are NULL
+ * @return   -2, if no memory could be allocated
+ * @return   -3, if no content with @p prefix was found to be removed
+*/
+int
+ccnl_cs_remove(struct ccnl_relay_s *ccnl, char *prefix);
+
 #endif //CCNL_RELAY_H
 /** @} */

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -1070,3 +1070,27 @@ ccnl_cs_add(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
 
     return -1;
 }
+
+int
+ccnl_cs_remove(struct ccnl_relay_s *ccnl, char *prefix)
+{
+    struct ccnl_content_s *c;
+
+    if (!ccnl || !prefix) {
+        return -1;
+    }
+
+    for (c = ccnl->contents; c; c = c->next) {
+        char *spref = ccnl_prefix_to_path(c->pkt->pfx);
+        if (!spref) {
+            return -2;
+        }
+        if (memcmp(prefix, spref, strlen(spref)) == 0) {
+            ccnl_free(spref);
+            ccnl_content_remove(ccnl, c);
+            return 0;
+        }
+        ccnl_free(spref);
+    }
+    return -3;
+}

--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -215,6 +215,18 @@ static inline void ccnl_msg_cs_add(struct ccnl_content_s *content)
     msg_send(&ms, ccnl_event_loop_pid);
 }
 
+/**
+ * @brief Send a message to the CCN-lite thread to remove a content with
+ * the @p prefix from the content store
+ *
+ * @param[in] content   The prefix of the content to remove from the content store
+ */
+static inline void ccnl_msg_cs_remove(struct ccnl_prefix_s *prefix)
+{
+    msg_t ms = { .type = CCNL_MSG_CS_DEL, .content.ptr = prefix };
+    msg_send(&ms, ccnl_event_loop_pid);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -450,6 +450,13 @@ void
                 content = (struct ccnl_content_s *)m.content.ptr;
                 ccnl_cs_add(ccnl, content);
                 break;
+            case CCNL_MSG_CS_DEL:
+                DEBUGMSG(VERBOSE, "ccn-lite: CS remove\n");
+                prefix = (char *)m.content.ptr;
+                if (ccnl_cs_remove(ccnl, prefix) < 0) {
+                    DEBUGMSG(WARNING, "removing CS entry failed\n");
+                }
+                break;
             default:
                 DEBUGMSG(WARNING, "ccn-lite: unknown message type\n");
                 break;


### PR DESCRIPTION
### Contribution description
Removes content from the content store in ccnls thread context.

See #254. ~~Depends on #254~~

### Issues/PRs references
none
