### PR TITLE
 ccnl-riot: lookup CS in ccnl thread context 

### DIFF
--- a/src/ccnl-core/include/ccnl-relay.h
+++ b/src/ccnl-core/include/ccnl-relay.h
@@ -276,5 +276,19 @@ ccnl_cs_add(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c);
 int
 ccnl_cs_remove(struct ccnl_relay_s *ccnl, char *prefix);
 
+/**
+ * @brief Lookup content from the Content Store with prefix @p prefix
+ *
+ * @param[in] ccnl      pointer to current ccnl relay
+ * @param[in] prefix    prefix of the content to lookup from the Content Store
+ *
+ * @return              pointer to the content, if found
+ * @return              NULL, if @p ccnl or @p prefix are NULL
+ * @return              NULL, on memory allocation failure
+ * @return              NULL, if not found
+*/
+struct ccnl_content_s *
+ccnl_cs_lookup(struct ccnl_relay_s *ccnl, char *prefix);
+
 #endif //CCNL_RELAY_H
 /** @} */

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -1094,3 +1094,26 @@ ccnl_cs_remove(struct ccnl_relay_s *ccnl, char *prefix)
     }
     return -3;
 }
+
+struct ccnl_content_s *
+ccnl_cs_lookup(struct ccnl_relay_s *ccnl, char *prefix)
+{
+    struct ccnl_content_s *c;
+
+    if (!ccnl || !prefix) {
+        return NULL;
+    }
+
+    for (c = ccnl->contents; c; c = c->next) {
+        char *spref = ccnl_prefix_to_path(c->pkt->pfx);
+        if (!spref) {
+            return NULL;
+        }
+        if (memcmp(prefix, spref, strlen(spref)) == 0) {
+            ccnl_free(spref);
+            return c;
+        }
+        ccnl_free(spref);
+    }
+    return NULL;
+}

--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -230,6 +230,22 @@ static inline void ccnl_msg_cs_remove(struct ccnl_prefix_s *prefix)
     msg_send(&ms, ccnl_event_loop_pid);
 }
 
+/**
+ * @brief Send a message to the CCN-lite thread to perform a content store
+ * lookup for the @p prefix
+ *
+ * @param[in] content   The prefix of the content to perform a lookup for
+ *
+ * @return              pointer to the content, if found
+ * @reutn               NULL, if not found
+ */
+static inline struct ccnl_content_s *ccnl_msg_cs_lookup(struct ccnl_prefix_s *prefix)
+{
+    msg_t mr, ms = { .type = CCNL_MSG_CS_LOOKUP, .content.ptr = prefix };
+    msg_send_receive(&ms, &mr, ccnl_event_loop_pid);
+    return (struct ccnl_content_s *) mr.content.ptr;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -453,10 +453,16 @@ void
                 break;
             case CCNL_MSG_CS_DEL:
                 DEBUGMSG(VERBOSE, "ccn-lite: CS remove\n");
-                prefix = (char *)m.content.ptr;
-                if (ccnl_cs_remove(ccnl, prefix) < 0) {
+                prefix = (struct ccnl_prefix_s *)m.content.ptr;
+                spref = ccnl_prefix_to_path(prefix);
+                if (!spref) {
+                    DEBUGMSG(WARNING, "ccn-lite: CS remove failed, because of no memory available\n");
+                    break;
+                }
+                if (ccnl_cs_remove(ccnl, spref) < 0) {
                     DEBUGMSG(WARNING, "removing CS entry failed\n");
                 }
+                ccnl_free(spref);
                 break;
             case CCNL_MSG_CS_LOOKUP:
                 DEBUGMSG(VERBOSE, "ccn-lite: CS lookup\n");


### PR DESCRIPTION
### Contribution description
Perform content lookup from the content store in ccnls thread context.

See #255. Depends on #255

### Issues/PRs references
none
