### PR TITLE
ccnl-callbacks: add support for on-data events

### DIFF
--- a/src/ccnl-core/include/ccnl-callbacks.h
+++ b/src/ccnl-core/include/ccnl-callbacks.h
@@ -25,21 +25,31 @@
 #include "ccnl-core.h"
 
 /**
- * @brief Function pointer callback type for inbound on-data events
+ * @brief Function pointer callback type for on-data events
  */
-typedef int (*ccnl_cb_rx_on_data)(struct ccnl_relay_s *relay,
-                                  struct ccnl_face_s *from,
-                                  struct ccnl_pkt_s *pkt);
+typedef int (*ccnl_cb_on_data)(struct ccnl_relay_s *relay,
+                               struct ccnl_face_s *face,
+                               struct ccnl_pkt_s *pkt);
 
 /**
- * @brief Set an inbound on-data callback function
+ * @brief Set an inbound on-data event callback function
  *
  * Setting an on-data callback function allows to intercept inbound Data
  * packets. The event is triggered before a Content Store lookup is performed.
  *
  * @param[in] func  The callback function for inbound on-data events
  */
-void ccnl_set_cb_rx_on_data(ccnl_cb_rx_on_data func);
+void ccnl_set_cb_rx_on_data(ccnl_cb_on_data func);
+
+/**
+ * @brief Set an outbound on-data event callback function
+ *
+ * Setting an on-data callback function allows to intercept outbound Data
+ * packets. The event is triggered after a Content Store lookup is performed.
+ *
+ * @param[in] func  The callback function for outbound on-data events
+ */
+void ccnl_set_cb_tx_on_data(ccnl_cb_on_data func);
 
 /**
  * @brief Callback for inbound on-data events
@@ -56,6 +66,23 @@ void ccnl_set_cb_rx_on_data(ccnl_cb_rx_on_data func);
  */
 int ccnl_callback_rx_on_data(struct ccnl_relay_s *relay,
                              struct ccnl_face_s *from,
+                             struct ccnl_pkt_s *pkt);
+
+/**
+ * @brief Callback for outbound on-data events
+ *
+ * @param[in] relay The active ccn-lite relay
+ * @param[in] from  The face the packet is sent over
+ * @param[in] pkt   The actual packet to send
+ *
+ * @note if the callback function returns any other value than 0,
+ *       then the data packet is not sent and discarded.
+ *
+ * @return return value of the callback function
+ * @return 0, if no function has been set
+ */
+int ccnl_callback_tx_on_data(struct ccnl_relay_s *relay,
+                             struct ccnl_face_s *to,
                              struct ccnl_pkt_s *pkt);
 
 #endif  /* CCNL_CALLBACKS_H */

--- a/src/ccnl-core/include/ccnl-callbacks.h
+++ b/src/ccnl-core/include/ccnl-callbacks.h
@@ -1,0 +1,61 @@
+/*
+ * @f ccnl-callbacks.h
+ * @b CCN lite, core CCNx protocol logic
+ *
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * File history:
+ * 2018-05-21 created (based on ccnl-producer.h)
+ */
+#ifndef CCNL_CALLBACKS_H
+#define CCNL_CALLBACKS_H
+
+#include "ccnl-core.h"
+
+/**
+ * @brief Function pointer callback type for inbound on-data events
+ */
+typedef int (*ccnl_cb_rx_on_data)(struct ccnl_relay_s *relay,
+                                  struct ccnl_face_s *from,
+                                  struct ccnl_pkt_s *pkt);
+
+/**
+ * @brief Set an inbound on-data callback function
+ *
+ * Setting an on-data callback function allows to intercept inbound Data
+ * packets. The event is triggered before a Content Store lookup is performed.
+ *
+ * @param[in] func  The callback function for inbound on-data events
+ */
+void ccnl_set_cb_rx_on_data(ccnl_cb_rx_on_data func);
+
+/**
+ * @brief Callback for inbound on-data events
+ *
+ * @param[in] relay The active ccn-lite relay
+ * @param[in] from  The face the packet was received over
+ * @param[in] pkt   The actual received packet 
+ *
+ * @note if the callback function returns any other value than 0,
+ *       then the data packet is discarded.
+ *
+ * @return return value of the callback function
+ * @return 0, if no function has been set
+ */
+int ccnl_callback_rx_on_data(struct ccnl_relay_s *relay,
+                             struct ccnl_face_s *from,
+                             struct ccnl_pkt_s *pkt);
+
+#endif  /* CCNL_CALLBACKS_H */

--- a/src/ccnl-core/src/ccnl-callbacks.c
+++ b/src/ccnl-core/src/ccnl-callbacks.c
@@ -25,12 +25,23 @@
 /**
  * callback function for inbound on-data events
  */
-static ccnl_cb_rx_on_data _cb_rx_on_data = NULL;
+static ccnl_cb_on_data _cb_rx_on_data = NULL;
+
+/**
+ * callback function for outbound on-data events
+ */
+static ccnl_cb_on_data _cb_tx_on_data = NULL;
 
 void
-ccnl_set_cb_rx_on_data(ccnl_cb_rx_on_data func)
+ccnl_set_cb_rx_on_data(ccnl_cb_on_data func)
 {
     _cb_rx_on_data = func;
+}
+
+void
+ccnl_set_cb_tx_on_data(ccnl_cb_on_data func)
+{
+    _cb_tx_on_data = func;
 }
 
 int
@@ -40,6 +51,18 @@ ccnl_callback_rx_on_data(struct ccnl_relay_s *relay,
 {
     if (_cb_rx_on_data) {
         return _cb_rx_on_data(relay, from, pkt);
+    }
+
+    return 0;
+}
+
+int
+ccnl_callback_tx_on_data(struct ccnl_relay_s *relay,
+                         struct ccnl_face_s *to,
+                         struct ccnl_pkt_s *pkt)
+{
+    if (_cb_tx_on_data) {
+        return _cb_tx_on_data(relay, to, pkt);
     }
 
     return 0;

--- a/src/ccnl-core/src/ccnl-callbacks.c
+++ b/src/ccnl-core/src/ccnl-callbacks.c
@@ -1,0 +1,46 @@
+/*
+ * @f ccnl-callbacks.c
+ * @b Callback functions
+ *
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ * File history:
+ * 2018-05-21 created (based on ccnl-producer.c)
+ */
+
+#include "ccnl-callbacks.h"
+
+/**
+ * callback function for inbound on-data events
+ */
+static ccnl_cb_rx_on_data _cb_rx_on_data = NULL;
+
+void
+ccnl_set_cb_rx_on_data(ccnl_cb_rx_on_data func)
+{
+    _cb_rx_on_data = func;
+}
+
+int
+ccnl_callback_rx_on_data(struct ccnl_relay_s *relay,
+                         struct ccnl_face_s *from,
+                         struct ccnl_pkt_s *pkt)
+{
+    if (_cb_rx_on_data) {
+        return _cb_rx_on_data(relay, from, pkt);
+    }
+
+    return 0;
+}

--- a/src/ccnl-fwd/src/ccnl-fwd.c
+++ b/src/ccnl-fwd/src/ccnl-fwd.c
@@ -25,6 +25,7 @@
 
 #include "ccnl-core.h"
 #include "ccnl-producer.h"
+#include "ccnl-callbacks.h"
 
 #include "ccnl-pkt-util.h"
 #ifdef USE_NFN
@@ -110,6 +111,11 @@ ccnl_fwd_handleContent(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
             return ccnl_crypto(relay, pkt->buf, pkt->pfx, from);
         }
 #endif /* USE_SUITE_CCNB && USE_SIGNATURES*/
+
+    if (ccnl_callback_rx_on_data(relay, from, *pkt)) {
+        *pkt = NULL;
+        return 0;
+    }
 
     // CONFORM: Step 1:
     for (c = relay->contents; c; c = c->next) {

--- a/src/ccnl-fwd/src/ccnl-fwd.c
+++ b/src/ccnl-fwd/src/ccnl-fwd.c
@@ -362,6 +362,11 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
             ccnl_nfn_monitor(relay, from, c->pkt->pfx, c->pkt->content,
                                  c->pkt->contlen);
 #endif
+
+            if (ccnl_callback_tx_on_data(relay, from, *pkt)) {
+                continue;
+            }
+
             ccnl_send_pkt(relay, from, c->pkt);
 #ifdef USE_NFN_REQUESTS
             c->pkt = cpkt;


### PR DESCRIPTION
### Contribution description
This PR adds callback function support for 1) outbound data packet events and 2) inbound data packet events. Data packets can thus be intercepted by another application (e.g. a routing protocol) and discarded if necessary. It's similar to the `local_producer` callback function.


### Issues/PRs references
none