### PR TITLE
ccnl-riot: face evtimer

### DIFF
--- a/src/ccnl-core/include/ccnl-face.h
+++ b/src/ccnl-core/include/ccnl-face.h
@@ -25,6 +25,10 @@
 
 #include "ccnl-sockunion.h"
 
+#ifdef CCNL_RIOT
+#include "evtimer_msg.h"
+#endif
+
 struct ccnl_face_s {
     struct ccnl_face_s *next, *prev;
     int faceid;
@@ -35,6 +39,9 @@ struct ccnl_face_s {
     struct ccnl_buf_s *outq, *outqend; // queue of packets to send
     struct ccnl_frag_s *frag;  // which special datagram armoring
     struct ccnl_sched_s *sched;
+#ifdef CCNL_RIOT
+    evtimer_msg_event_t evtmsg_timeout;
+#endif
 };
 
 void

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -61,6 +61,9 @@ ccnl_get_face_or_create(struct ccnl_relay_s *ccnl, int ifndx,
         if (ifndx != -1 && (f->ifndx == ifndx) &&
             !ccnl_addr_cmp(&f->peer, (sockunion*)sa)) {
             f->last_used = CCNL_NOW();
+#ifdef CCNL_RIOT
+            ccnl_evtimer_reset_face_timeout(f);
+#endif
             return f;
         }
     }
@@ -102,6 +105,11 @@ ccnl_get_face_or_create(struct ccnl_relay_s *ccnl, int ifndx,
     DBL_LINKED_LIST_ADD(ccnl->faces, f);
 
     TRACEOUT();
+
+#ifdef CCNL_RIOT
+    ccnl_evtimer_reset_face_timeout(f);
+#endif
+
     return f;
 }
 

--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -133,6 +133,11 @@ extern kernel_pid_t ccnl_event_loop_pid;
 #define CCNL_MSG_INT_TIMEOUT    (0x1707)
 
 /**
+ * Message type for Face timeouts
+ */
+#define CCNL_MSG_FACE_TIMEOUT   (0x1708)
+
+/**
  * Maximum number of elements that can be cached
  */
 #ifndef CCNL_CACHE_SIZE
@@ -297,6 +302,20 @@ static inline void ccnl_evtimer_reset_interest_timeout(struct ccnl_interest_s *i
     i->evtmsg_timeout.msg.content.ptr = i;
     ((evtimer_event_t *)&i->evtmsg_timeout)->offset = i->lifetime * 1000; // ms
     evtimer_add_msg(&ccnl_evtimer, &i->evtmsg_timeout, ccnl_event_loop_pid);
+}
+
+/**
+ * @brief Reset Face timeout
+ *
+ * @param[in] f         The face to update
+ */
+static inline void ccnl_evtimer_reset_face_timeout(struct ccnl_face_s *f)
+{
+    evtimer_del((evtimer_t *)(&ccnl_evtimer), (evtimer_event_t *)&f->evtmsg_timeout);
+    f->evtmsg_timeout.msg.type = CCNL_MSG_FACE_TIMEOUT;
+    f->evtmsg_timeout.msg.content.ptr = f;
+    ((evtimer_event_t *)&f->evtmsg_timeout)->offset = CCNL_FACE_TIMEOUT * 1000; // ms
+    evtimer_add_msg(&ccnl_evtimer, &f->evtmsg_timeout, ccnl_event_loop_pid);
 }
 
 #ifdef __cplusplus

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -366,6 +366,7 @@ void
     struct ccnl_pkt_s *pkt;
     struct ccnl_prefix_s *prefix;
     struct ccnl_interest_s *ccnl_int;
+    struct ccnl_face_s *face;
     char *spref;
 
     msg_init_queue(_msg_queue, CCNL_QUEUE_SIZE);
@@ -437,6 +438,13 @@ void
             case CCNL_MSG_INT_TIMEOUT:
                 ccnl_int = (struct ccnl_interest_s *)m.content.ptr;
                 ccnl_interest_remove(ccnl, ccnl_int);
+                break;
+            case CCNL_MSG_FACE_TIMEOUT:
+                face = (struct ccnl_face_s *)m.content.ptr;
+                if (face &&
+                    !(face->flags & CCNL_FACE_FLAGS_STATIC)) {
+                    ccnl_face_remove(ccnl, face);
+                }
                 break;
             default:
                 DEBUGMSG(WARNING, "ccn-lite: unknown message type\n");


### PR DESCRIPTION
### Contribution description
Use `evtimer` of RIOT for face timeouts.


### Issues/PRs references
none
