### PR TITLE
ccnl/riot: move reset of retransmission timer

### DIFF
--- a/src/ccnl-core/src/ccnl-interest.c
+++ b/src/ccnl-core/src/ccnl-interest.c
@@ -116,11 +116,6 @@ ccnl_interest_append_pending(struct ccnl_interest_s *i,  struct ccnl_face_s *fro
         return -1;
     }
 
-#ifdef CCNL_RIOT
-    ccnl_evtimer_reset_interest_retrans(i);
-    ccnl_evtimer_reset_interest_timeout(i);
-#endif
-
     DEBUGMSG_CORE(DEBUG, "  appending a new pendint entry %p <%s>(%p)\n",
                   (void *) pi, ccnl_prefix_to_str(i->pkt->pfx,s,CCNL_MAX_PREFIX_SIZE),
                   (void *) i->pkt->pfx);

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -336,6 +336,11 @@ ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
     i->last_used = CCNL_NOW();
     DBL_LINKED_LIST_ADD(ccnl->pit, i);
 
+#ifdef CCNL_RIOT
+    ccnl_evtimer_reset_interest_retrans(i);
+    ccnl_evtimer_reset_interest_timeout(i);
+#endif
+
     return i;
 }
 


### PR DESCRIPTION
### Contribution description

Both retransmission and Interest timeout timers should be (re-)set only on the first Interest for one name, *not* when aggregating PIT entries. 

Currently, when two nodes request the same data from the same forwarder, the second Interest resets the initial retransmission timer on that node. With increasing numbers of nodes requesting the same data as well as increasing retransmission timeouts, the effect amplifies. To fix that, we only (re-)set the timer on the initial Interest for one name.

(With increased retransmission timouts of 5 seconds and Interest lifetime of 25 seconds)

**Old:**
The first retransmission by the forwarder (src=96:40:b6:33:93:c8) has been delayed in cause of resetting the retransmission timer by the second Interest request for one name.
![old](https://user-images.githubusercontent.com/7765855/40474774-3100a1bc-5f40-11e8-942d-f8e1337eb767.png)

**New:**
The first retransmission by the forwarder (src=96:40:b6:33:93:c8) is done after 5 seconds as expected.
![new](https://user-images.githubusercontent.com/7765855/40474770-2ae160fa-5f40-11e8-8603-11456ccc4bd9.png)


### Issues/PRs references
Improves #259
