### PR TITLE
ccnl/riot: cache timeout based on evtimer

### DIFF
--- a/src/ccnl-core/include/ccnl-content.h
+++ b/src/ccnl-core/include/ccnl-content.h
@@ -26,6 +26,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef CCNL_RIOT
+#include "evtimer_msg.h"
+#endif
+
 struct ccnl_pkt_s;
 struct ccnl_prefix_s;
 
@@ -45,6 +49,9 @@ struct ccnl_content_s {
 #endif
 
     int served_cnt;
+#ifdef CCNL_RIOT
+    evtimer_msg_event_t evtmsg_cstimeout;
+#endif
 };
 
 struct ccnl_content_s*

--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -318,6 +318,20 @@ static inline void ccnl_evtimer_reset_face_timeout(struct ccnl_face_s *f)
     evtimer_add_msg(&ccnl_evtimer, &f->evtmsg_timeout, ccnl_event_loop_pid);
 }
 
+/**
+ * @brief Set content timeout
+ *
+ * @param[in] c         The content to timeout
+ */
+static inline void ccnl_evtimer_set_cs_timeout(struct ccnl_content_s *c)
+{
+    evtimer_del((evtimer_t *)(&ccnl_evtimer), (evtimer_event_t *)&c->evtmsg_cstimeout);
+    c->evtmsg_cstimeout.msg.type = CCNL_MSG_CS_DEL;
+    c->evtmsg_cstimeout.msg.content.ptr = c->pkt->pfx;
+    ((evtimer_event_t *)&c->evtmsg_cstimeout)->offset = CCNL_CONTENT_TIMEOUT * 1000; // ms
+    evtimer_add_msg(&ccnl_evtimer, &c->evtmsg_cstimeout, ccnl_event_loop_pid);
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description

After removal of the "ticking" aging function in #259, we need to cache out CS entries via events.

To test this, you can use the RIOT example [ccn-lite-relay](https://github.com/RIOT-OS/RIOT/tree/master/examples/ccn-lite-relay) *but* you need to get rid of the static content flag which is set in the respective shell handler [here](https://github.com/RIOT-OS/RIOT/blob/master/sys/shell/commands/sc_ccnl.c#L134). Furthermore it might make sense to reduce the content timeout (e.g., `CFLAGS=-DCCNL_CONTENT_TIMEOUT=10`)


### Issues/PRs references
#259