### PR TITLE
ccnl/riot: make debug message unique

### DIFF
--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -209,7 +209,7 @@ ccnl_ll_TX(struct ccnl_relay_s *ccnl, struct ccnl_if_s *ifc,
                                                                  GNRC_NETTYPE_CCN);
 
                             if (pkt == NULL) {
-                                puts("error: packet buffer full");
+                                printf("error: packet buffer full trying to allocate %d bytes\n", buf->datalen);
                                 return;
                             }
 
@@ -236,7 +236,7 @@ ccnl_ll_TX(struct ccnl_relay_s *ccnl, struct ccnl_if_s *ifc,
 
                             /* check if header building succeeded */
                             if (hdr == NULL) {
-                                puts("error: packet buffer full");
+                                puts("error: packet buffer full trying to allocate netif_hdr");
                                 gnrc_pktbuf_release(pkt);
                                 return;
                             }


### PR DESCRIPTION
### Contribution description
This PR adapts two warnings thrown by the RIOT adapter in case no memory can be allocated in the packet buffer. To better distinguish between both outputs, I made them unique.