### PR TITLE
fixes ccnl_content_add2cache prefix comparison

### DIFF
--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -570,8 +570,9 @@ ccnl_content_add2cache(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
     DEBUGMSG_CORE(DEBUG, "ccnl_content_add2cache (%d/%d) --> %p = %s [%d]\n",
                   ccnl->contentcnt, ccnl->max_cache_entries,
                   (void*)c, ccnl_prefix_to_str(c->pkt->pfx,s,CCNL_MAX_PREFIX_SIZE), (c->pkt->pfx->chunknum)? *(c->pkt->pfx->chunknum) : -1);
+
     for (cit = ccnl->contents; cit; cit = cit->next) {
-        if (c == cit) {
+        if (ccnl_prefix_cmp(c->pkt->pfx, NULL, cit->pkt->pfx, CMP_EXACT) == 0) {
             DEBUGMSG_CORE(DEBUG, "--- Already in cache ---\n");
             return NULL;
         }


### PR DESCRIPTION

### Contribution description

This PR addresses an issue in function ``ccnl_content_add2cache `` in `` ccnl_relay.c``. Currently, the function checks if the pointer passed to the function has been added before and hence, duplicate content is added to the content store. The function replaces the comparison of pointers with a call to ``ccnl_prefix_cmp`` which checks if the prefix content to be added **exactly** matches an existing entry in the content store.


### Issues/PRs references

Fixes #200 
