### PR TITLE
replaces int parameters in calloc/malloc/realloc calls with size_t

### DIFF
--- a/src/ccnl-core/include/ccnl-malloc.h
+++ b/src/ccnl-core/include/ccnl-malloc.h
@@ -1,8 +1,11 @@
-/*
- * @f ccnl-malloc.h
- * @b CCN lite (CCNL), core header file (internal data structures)
+/**
+ * @addtogroup CCNL-core
+ * @{
  *
- * Copyright (C) 2011-17, University of Basel
+ * @file ccnl-malloc.h
+ * @brief Malloc (re-)definition of CCN-lite
+ *
+ * Copyright (C) 2011-18, University of Basel
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -15,13 +18,9 @@
  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * File history:
- * 2017-06-16 created
  */
-
- #ifndef CCNL_MALLOC_H
- #define CCNL_MALLOC_H
+#ifndef CCNL_MALLOC_H
+#define CCNL_MALLOC_H
 
 #ifndef CCNL_LINUXKERNEL
 #include <stdlib.h>
@@ -34,7 +33,8 @@
 struct mhdr {
     struct mhdr *next;
     char *fname;
-    int lineno, size;
+    int lineno;
+    size_t size;
 #ifdef CCNL_ARDUINO
     double tstamp;
 #else
@@ -46,14 +46,14 @@ struct mhdr {
 
 #ifdef USE_DEBUG_MALLOC
 
-void *debug_realloc(void *p, int s, const char *fn, int lno);
+void *debug_realloc(void *p, size_t s, const char *fn, int lno);
 void debug_free(void *p, const char *fn, int lno);
 
 #ifdef CCNL_ARDUINO
 void*
-debug_malloc(int s, const char *fn, int lno, double tstamp);
+debug_malloc(size_t num, size_t size, const char *fn, int lno, double tstamp);
 void*
-debug_calloc(int n, int s, const char *fn, int lno, double tstamp);
+debug_calloc(size_t num, size_t size, const char *fn, int lno, double tstamp);
 void*
 debug_strdup(const char *s, const char *fn, int lno, double tstamp);
 
@@ -65,9 +65,9 @@ debug_strdup(const char *s, const char *fn, int lno, double tstamp);
 
 #else 
 void*
-debug_malloc(int s, const char *fn, int lno, char *tstamp);
+debug_malloc(size_t s, const char *fn, int lno, char *tstamp);
 void* 
-debug_calloc(int n, int s, const char *fn, int lno, char *tstamp);
+debug_calloc(size_t num, size_t size, const char *fn, int lno, char *tstamp);
 void*
 debug_strdup(const char *s, const char *fn, int lno, char *tstamp);
 
@@ -100,14 +100,23 @@ debug_strdup(const char *s, const char *fn, int lno, char *tstamp);
 #ifdef CCNL_LINUXKERNEL
 
 
+/**
+ * @brief Allocates a block of size bytes of memory, returning a pointer to the beginning of the block.
+ *
+ * @param[in] size Size of the memory block, in bytes
+ *
+ * @return Upon failure, the function returns NULL
+ * @return Upon success, a pointer to the memory block allocated by the function
+ */
 static inline void*
-ccnl_malloc(int s);
+ccnl_malloc(size_t s);
 
 static inline void*
-ccnl_calloc(int n, int s);
+ccnl_calloc(size_t num, size_t size);
 
 static inline void
 ccnl_free(void *ptr);
 #endif
 
-#endif //CCNL_MALLOC_H
+#endif 
+/** @} */

--- a/src/ccnl-core/src/ccnl-logging.c
+++ b/src/ccnl-core/src/ccnl-logging.c
@@ -110,7 +110,7 @@ debug_memdump(void)
         CONSOLE(":%d @%d.%03d\n", h->lineno,
                 int(h->tstamp), int(1000*(h->tstamp - int(h->tstamp))));
 #else
-        CONSOLE("addr %p %5d Bytes, %s:%d @%s\n",
+        CONSOLE("addr %p %lu Bytes, %s:%d @%s\n",
                 (void *)(h + sizeof(struct mhdr)),
                 h->size, getBaseName(h->fname), h->lineno, h->tstamp);
 #endif

--- a/src/ccnl-core/src/ccnl-malloc.c
+++ b/src/ccnl-core/src/ccnl-malloc.c
@@ -64,6 +64,7 @@ void*
 debug_calloc(size_t n, size_t s, const char *fn, int lno, char *tstamp)
 #endif
 {
+    /** TODO: potential integer overflow by n * z operation */
     void *p = debug_malloc(n * s, fn, lno, tstamp);
     if (p)
         memset(p, 0, n*s);

--- a/src/ccnl-core/src/ccnl-malloc.c
+++ b/src/ccnl-core/src/ccnl-malloc.c
@@ -27,10 +27,10 @@
 
 #ifdef CCNL_ARDUINO
 void*
-debug_malloc(int s, const char *fn, int lno, double tstamp)
+debug_malloc(size_t s, const char *fn, int lno, double tstamp)
 #else
 void*
-debug_malloc(int s, const char *fn, int lno, char *tstamp)
+debug_malloc(size_t s, const char *fn, int lno, char *tstamp)
 #endif
 {
     struct mhdr *h = (struct mhdr *) malloc(s + sizeof(struct mhdr));
@@ -58,10 +58,10 @@ debug_malloc(int s, const char *fn, int lno, char *tstamp)
 
 #ifdef CCNL_ARDUINO
 void*
-debug_calloc(int n, int s, const char *fn, int lno, double tstamp)
+debug_calloc(size_t n, size_t s, const char *fn, int lno, double tstamp)
 #else
 void*
-debug_calloc(int n, int s, const char *fn, int lno, char *tstamp)
+debug_calloc(size_t n, size_t s, const char *fn, int lno, char *tstamp)
 #endif
 {
     void *p = debug_malloc(n * s, fn, lno, tstamp);
@@ -87,7 +87,7 @@ debug_unlink(struct mhdr *hdr)
 }
 
 void*
-debug_realloc(void *p, int s, const char *fn, int lno)
+debug_realloc(void *p, size_t s, const char *fn, int lno)
 {
     struct mhdr *h = (struct mhdr *) (((unsigned char *)p) - sizeof(struct mhdr));
 


### PR DESCRIPTION
### Contribution description

This PR replaces the ``int`` parameters for sizes in ``malloc``/``calloc``/``realloc`` function definitions in ``ccnl-malloc.{c,h}`` with ``size_t``. It also replaces the number of element parameter ``n`` of ``calloc`` with ``size_t``. This also results in a minor modification to ``struct mhdr`` which holds information on allocated memory (replacing the ``size`` parameter of type ``int`` with ``size_t`` results in a larger struct (in terms of used memory))

### Issues/PRs references

This PR addresses #175 and is related to #271.