### PR TITLE
Fix possible heap bufferoverrun when reading ndn- or ccnx-files

### DIFF
--- a/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
@@ -44,7 +44,6 @@
 int
 ccnl_ndntlv_varlenint(unsigned char **buf, int *len, int *val)
 {
-
     if (**buf < 253 && *len >= 1) {
         *val = **buf;
         *buf += 1;

--- a/src/ccnl-utils/src/ccn-lite-ctrl.c
+++ b/src/ccnl-utils/src/ccn-lite-ctrl.c
@@ -679,7 +679,8 @@ mkAddToRelayCacheRequest(unsigned char *out, char *fname,
     fseek(file, 0L, SEEK_END);
     datalen = ftell(file);
     fseek(file, 0L, SEEK_SET);
-    data = (unsigned char *) ccnl_malloc(sizeof(unsigned char)*datalen);
+    data = (unsigned char *) ccnl_malloc(sizeof(unsigned char)*datalen+1);
+    memset(data, 0, sizeof(unsigned char)*datalen+1);
     fread(data, datalen, 1, file);
     fclose(file);
 


### PR DESCRIPTION
This Patch prevents a heap bufferoverrun when reading ndn- or ccnx-files and thus it fixes Issue #279 