### PR TITLE
removed unused variable in get_pendint_dump

### DIFF
--- a/src/ccnl-core/include/ccnl-dump.h
+++ b/src/ccnl-core/include/ccnl-dump.h
@@ -1,8 +1,8 @@
-/*
- * @f ccnl-dump.h
- * @b CCN lite extension
+/**
+ * @file  ccnl-dump.h
+ * @brief CCN lite extension
  *
- * Copyright (C) 2012-17, University of Basel
+ * Copyright (C) 2012-18, University of Basel
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -15,32 +15,32 @@
  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * File history:
- * 2012-05-06 created
- * 2013-10-21 extended for crypto <christopher.scherb@unibas.ch>
- * 2017-26-06 adapted to ccnl v2
  */
 
 #ifndef CCNL_DUMP_H
 #define CCNL_DUMP_H
 
-//#ifdef USE_DEBUG
+/**
+ * @brief A macro which prints @p n whitespace characters
+ */
+#define INDENT(n)   for (i = 0; i < (n); i++) CONSOLE("  ")
 
-enum { // numbers for each data type
-    CCNL_BUF = 1,
-    CCNL_PREFIX,
-    CCNL_RELAY,
-    CCNL_FACE,
-    CCNL_FRAG,
-    CCNL_FWD,
-    CCNL_INTEREST,
-    CCNL_PENDINT,
-    CCNL_PACKET,
-    CCNL_CONTENT
+/**
+ * @brief Lists different packet types and data structures for @ref ccnl_dump
+ */
+enum { 
+    CCNL_BUF = 1,               /**< data type is a buffer */
+    CCNL_PREFIX,                /**< data type is a prefix */
+    CCNL_RELAY,                 /**< data type is a relay */
+    CCNL_FACE,                  /**< data type is a face */
+    CCNL_FRAG,                  /**< data type is a fragment */
+    CCNL_FWD,                   /**< data type is a fib entry */
+    CCNL_INTEREST,              /**< data type is an interest */
+    CCNL_PENDINT,               /**< data type is pending interest */
+    CCNL_PACKET,                /**< data type is packet */
+    CCNL_CONTENT,               /**< data type is content */
+    CCNL_DO_NOT_USE = UINT8_MAX /**< for internal use only, sets the width of the enum to sizeof(uint8_t) */
 };
-
-//char* ccnl_addr2ascii(sockunion *su);
 
 char *frag_protocol(int e);
 void ccnl_dump(int lev, int typ, void *p);
@@ -54,10 +54,19 @@ int get_num_interface(void *p);
 int get_interface_dump(int lev, void *p, int *ifndx, char **addr, long *dev, int *devtype, int *reflect);
 int get_num_interests(void *p);
 int get_interest_dump(int lev, void *p, long *interest, long *next, long *prev, int *last, int *min, int *max, int *retries, long *publisher, int *prefixlen, char **prefix);
+
+/**
+ * @brief Writes PIT entries to @p out (an array of arrays).
+ *
+ * @param[in] lev The number of spaces to indent the log output (defunct)
+ * @param[in] p A pointer to the global @ref struct ccnl_relay_s 
+ * @param[out] out A array of arrays where the PIT is written to
+ *
+ * @return The number of entries written for the PIT
+ */
 int get_pendint_dump(int lev, void *p, char **out);
+
 int get_num_contents(void *p);
 int get_content_dump(int lev, void *p, long *content, long *next, long *prev, int *last_use, int *served_cnt, int *prefixlen, char **prefix);
-
-//#endif
 
 #endif // CCNL_DUMP_H

--- a/src/ccnl-core/src/ccnl-dump.c
+++ b/src/ccnl-core/src/ccnl-dump.c
@@ -72,8 +72,6 @@ ccnl_dump(int lev, int typ, void *p)
     char s[CCNL_MAX_PREFIX_SIZE];
     (void) s;
 
-    #define INDENT(lev)   for (i = 0; i < (lev); i++) CONSOLE("  ")
-
     switch (typ) {
         case CCNL_BUF:
             while (buf) {
@@ -488,22 +486,33 @@ get_interest_dump(int lev, void *p, long *interest, long *next, long *prev,
 }
 
 int
-get_pendint_dump(int lev, void *p, char **out){
-    struct ccnl_relay_s *top = (struct ccnl_relay_s    *) p;
-    struct ccnl_interest_s *itr = (struct ccnl_interest_s *) top->pit;
-    struct ccnl_pendint_s  *pir = (struct ccnl_pendint_s  *) itr->pending;
+get_pendint_dump(int lev, void *p, char **out) {
+    /* remove compiler warning on unused variable */
+    (void) lev;
 
-    int pos = 0, line = 0;
-    (void)lev;
+    struct ccnl_relay_s *top = (struct ccnl_relay_s *) p;
+    struct ccnl_interest_s *itr = (struct ccnl_interest_s *) top->pit;
+    struct ccnl_pendint_s *pir = (struct ccnl_pendint_s *) itr->pending;
+
+    int line = 0;
+    int result = 0;
+
     while (pir) {
-//        INDENT(lev);
-        pos = 0;
-        pos += sprintf(out[line] + pos, "%p PENDINT next=%p face=%p last=%d",
+        /* indent entry by 'lev' spaces */
+        //INDENT(lev);
+
+        /* check if the sprintf call fails */
+        if ((result = sprintf(out[line], "%p PENDINT next=%p face=%p last=%d",
                        (void *) pir, (void *) pir->next,
-                       (void *) pir->face, pir->last_used);
+                       (void *) pir->face, pir->last_used)) < 0) { 
+            DEBUGMSG(ERROR, "get_pendint_dump: could not write PIT entry\n");
+        }
+        /* set pointer to next entry */
         pir = pir->next;
+        /* new entry in pit */
         ++line;
     }
+
     return line;
 }
 


### PR DESCRIPTION
### Contribution description

This PR addresses #272. It removes the ``pos`` variable and adds some documentation. Unlike the suggestion in the ticket, the ``sprintf`` call is not replaced with a ``snprintf`` call. This is mostly due to the fact that an array of arrays is passed to the function and hence, an array of arrays with length parameters would have needed to be passed to the function (or either limit the size of the entries to a max value). However, the function is never called (yet). 

### Issues/PRs references

Fixes #272. 