### PR TITLE
adds script for running clang-analyzer

### DIFF
--- a/scan-build.sh
+++ b/scan-build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# check if scan-build is in path
+if ! hash scan-build 2>/dev/null
+then
+    echo "'scan-build' was not found in PATH"
+else
+mkdir -p build \
+	&& cd build \
+	&& scan-build -o scanbuildout cmake .. \
+	&& scan-build -o scanbuildout make
+fi


### PR DESCRIPTION
### Contribution description

Provides a shell script which checks if ``scan-build`` (part of clang-analyzer) is installed and runs it. The results of scan-build can be checked in ``build/scanbuildout``.

