### PR TITLE
resolves dereference issues in various functions

### DIFF
--- a/src/ccnl-core/src/ccnl-dump.c
+++ b/src/ccnl-core/src/ccnl-dump.c
@@ -310,19 +310,24 @@ get_buf_dump(int lev, void *p, long *outbuf, int *len, long *next)
     return line;
 }
 
-int
-get_prefix_dump(int lev, void *p, int *len, char** val)
+int get_prefix_dump(int lev, void *p, int *len, char** val)
 {
-    struct ccnl_prefix_s   *pre = (struct ccnl_prefix_s   *) p;
-    char s[CCNL_MAX_PREFIX_SIZE];
-//    int i;
-//    INDENT(lev);
-    //*prefix =  (void *) pre;
+    /* silence compiler warning */
     (void)lev;
-    *len = pre->compcnt;
-    //*val = ccnl_prefix_to_path(pre);
-    sprintf(*val, "%s", ccnl_prefix_to_str(pre,s,CCNL_MAX_PREFIX_SIZE));
-    return 1;
+
+    /* buffer for ccnl_prefix_to_str */
+    char s[CCNL_MAX_PREFIX_SIZE];
+    
+    struct ccnl_prefix_s *pre = (struct ccnl_prefix_s *) p;
+
+    if (pre) {
+//    INDENT(lev);
+        *len = pre->compcnt;
+        sprintf(*val, "%s", ccnl_prefix_to_str(pre,s,CCNL_MAX_PREFIX_SIZE));
+        return 1;
+    }
+
+    return -1;
 }
 
 int

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -900,7 +900,14 @@ ccnl_fib_rem_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
             break;
         }
     }
-    DEBUGMSG_CUTL(DEBUG, "added FIB via %s\n", ccnl_addr2ascii(&fwd->face->peer));
+
+    if (fwd) {
+        if (fwd->face) {
+            if (fwd->face->peer) {
+                DEBUGMSG_CUTL(DEBUG, "added FIB via %s\n", ccnl_addr2ascii(&fwd->face->peer));
+            }
+        }
+    }
 
     return res;
 }

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -903,7 +903,7 @@ ccnl_fib_rem_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
 
     if (fwd) {
         if (fwd->face) {
-            if (fwd->face->peer) {
+            if (&fwd->face->peer) {
                 DEBUGMSG_CUTL(DEBUG, "added FIB via %s\n", ccnl_addr2ascii(&fwd->face->peer));
             }
         }

--- a/src/ccnl-fwd/src/ccnl-fwd.c
+++ b/src/ccnl-fwd/src/ccnl-fwd.c
@@ -250,13 +250,17 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
             continue;
 
         DEBUGMSG_CFWD(DEBUG, "  found matching content %p\n", (void *) c);
-        if (from->ifndx >= 0) {
-            ccnl_send_pkt(relay, from, c->pkt);
-        } else {
-#ifdef CCNL_APP_RX
-            ccnl_app_RX(relay, c);
-#endif
+
+        if (from) {
+            if (from->ifndx >= 0) {
+                ccnl_send_pkt(relay, from, c->pkt);
+            } else {
+#ifdef CCNL_APP_RX 
+                ccnl_app_RX(relay, c);
+#endif 
+            }
         }
+
         return 0; // we are done
     }
 


### PR DESCRIPTION
### Contribution description

Adds NULL checks on pointer in order to avoid potential dereferences of a NULL pointer. All these issues were identified by LLVMs ``scan-build``
