### PR TITLE
Update README-unix.md

### DIFF
--- a/doc/README-unix.md
+++ b/doc/README-unix.md
@@ -3,7 +3,7 @@
 ## Prerequisites
 
 CCN-lite requires OpenSSL. Use the following to install it:
-* Ubuntu: `sudo apt-get install libssl-dev cmake`
+* Ubuntu: `sudo apt-get install cmake libssl-dev pkg-config && pkg-config libssl-dev`
 * macOS: `brew install openssl cmake`
 
 ## Installation


### PR DESCRIPTION
On newer Ubuntu Versions libssl-dev must be configured. This patches addes information about this to the readme.
