### PR TITLE
addressed 'NULL' issue in ccnl_i_prefixof_c

### DIFF
--- a/src/ccnl-core/include/ccnl-prefix.h
+++ b/src/ccnl-core/include/ccnl-prefix.h
@@ -119,6 +119,8 @@ ccnl_prefix_cmp(struct ccnl_prefix_s *pfx, unsigned char *md,
  * @param[in] c             Content to test the prefix against
  *
  * @return      -1 if no match at all (all modes) or exact match failed
+ * @return      -2 mismatch in expected number of components between prefix and content
+ * @return      -3 computation of digest failed 
  * @return      0 if full match
  * @return      n>0 for matched components
 */


### PR DESCRIPTION
### Contribution description
This issue was identified by clangs static analyzer ("argument with 'nonnull' attribute passed null"). If the check in
``` C
415     md = (prefix->compcnt - p->compcnt == 1) ? compute_ccnx_digest(c->pkt->buf) : NULL;
```
would fail, the subsequent call to 
```C
416 return ccnl_prefix_cmp(p, md, prefix, CMP_MATCH) == prefix->compcnt;
```
might also fail (i.e. ``md`` is ``NULL``). 