### PR TITLE
fix issues with ccn-lite-riot

### DIFF
--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -903,9 +903,7 @@ ccnl_fib_rem_entry(struct ccnl_relay_s *relay, struct ccnl_prefix_s *pfx,
 
     if (fwd) {
         if (fwd->face) {
-            if (&fwd->face->peer) {
-                DEBUGMSG_CUTL(DEBUG, "added FIB via %s\n", ccnl_addr2ascii(&fwd->face->peer));
-            }
+            DEBUGMSG_CUTL(DEBUG, "added FIB via %s\n", ccnl_addr2ascii(&fwd->face->peer));
         }
     }
 

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -209,7 +209,7 @@ ccnl_ll_TX(struct ccnl_relay_s *ccnl, struct ccnl_if_s *ifc,
                                                                  GNRC_NETTYPE_CCN);
 
                             if (pkt == NULL) {
-                                printf("error: packet buffer full trying to allocate %d bytes\n", buf->datalen);
+                                printf("error: packet buffer full trying to allocate %d bytes\n", (int)buf->datalen);
                                 return;
                             }
 


### PR DESCRIPTION
<!--
Before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the CCN-lite
coding conventions, see https://github.com/cn-uofbasel/ccn-lite/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes two issues found when compiling CCN-lite for RIOT on macOS.

first:
```
/RIOT/examples/ccn-lite-relay/bin/pkg/native/ccn-lite/src/ccnl-riot/src/ccn-lite-riot.c:212:99: error: format specifies type 'int' but the argument has type 'ssize_t' (aka 'long') [-Werror,-Wformat]
                                printf("error: packet buffer full trying to allocate %d bytes\n", buf->datalen);
                                                                                     ~~           ^~~~~~~~~~~~
                                                                                     %zd
1 warning and 1 error generated.
```

second:
```
/RIOT/examples/ccn-lite-relay/bin/pkg/native/ccn-lite/src/ccnl-core/src/ccnl-relay.c:906:29: error: address of 'fwd->face->peer' will always evaluate to 'true' [-Werror,-Wpointer-bool-conversion]
            if (&fwd->face->peer) {
            ~~   ~~~~~~~~~~~^~~~
1 warning and 1 error generated.
```

Note: need to update package version in RIOT.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->