### PR TITLE
removes unused function ccnl_core_addToCleanup

### DIFF
--- a/src/ccn-lite-simu.c
+++ b/src/ccn-lite-simu.c
@@ -51,7 +51,6 @@
 #include "ccnl-core.h"
 #include "ccnl-ext.h"
 
-void ccnl_core_addToCleanup(struct ccnl_buf_s *buf);
 #define local_producer(...) 0
 #define cache_strategy_remove(...)      0
 

--- a/src/ccnl-core/include/ccnl-buf.h
+++ b/src/ccnl-core/include/ccnl-buf.h
@@ -45,9 +45,6 @@ ccnl_buf_new(void *data, int len);
                          !memcmp(X->data,Y->data,X->datalen))
 
 void
-ccnl_core_addToCleanup(struct ccnl_buf_s *buf);
-
-void
 ccnl_core_cleanup(struct ccnl_relay_s *ccnl);
     
 #endif //CCNL_BUF_H

--- a/src/ccnl-core/include/ccnl-relay.h
+++ b/src/ccnl-core/include/ccnl-relay.h
@@ -58,8 +58,6 @@ struct ccnl_relay_s {
     struct ccnl_http_s *http;  /**< http server for status information*/
 #endif
     void *aux;
-
-   // struct ccnl_buf_s *bufCleanUpList;
   /*
     struct ccnl_face_s *crypto_face;
     struct ccnl_pendcrypt_s *pendcrypt;

--- a/src/ccnl-core/src/ccnl-buf.c
+++ b/src/ccnl-core/src/ccnl-buf.c
@@ -53,15 +53,6 @@ ccnl_buf_new(void *data, int len)
     return b;
 }
 
-struct ccnl_buf_s *bufCleanUpList;
-
-void
-ccnl_core_addToCleanup(struct ccnl_buf_s *buf)
-{
-    buf->next = bufCleanUpList;
-    bufCleanUpList = buf;
-}
-
 void
 ccnl_core_cleanup(struct ccnl_relay_s *ccnl)
 {
@@ -88,10 +79,4 @@ ccnl_core_cleanup(struct ccnl_relay_s *ccnl)
     }
     for (k = 0; k < ccnl->ifcount; k++)
         ccnl_interface_cleanup(ccnl->ifs + k);
-
-    while (bufCleanUpList) {
-        struct ccnl_buf_s *tmp = bufCleanUpList->next;
-        ccnl_free(bufCleanUpList);
-        bufCleanUpList = tmp;
-    }
 }

--- a/src/ccnl-utils/include/ccnl-common.h
+++ b/src/ccnl-utils/include/ccnl-common.h
@@ -77,7 +77,6 @@ int ccnl_pkt_prependComponent(int suite, char *src, int *offset, unsigned char *
 
 #include "ccnl-socket.h"
 
-#define ccnl_core_addToCleanup(b)       do{}while(0)
 
 // include only the utils, not the core routines:
 #ifdef USE_FRAG

--- a/src/ccnl-utils/src/ccnl-common.c
+++ b/src/ccnl-utils/src/ccnl-common.c
@@ -90,8 +90,6 @@ int ccnl_pkt_prependComponent(int suite, char *src, int *offset, unsigned char *
 
 #include "ccnl-socket.c"
 
-#define ccnl_core_addToCleanup(b)       do{}while(0)
-
 // include only the utils, not the core routines:
 #ifdef USE_FRAG
 #include "../ccnl-frag.h"


### PR DESCRIPTION
### Contribution description
This PR removes the unused member ``bufCleanUpList`` in ``ccnl_relay.h`` and removes also the unused function ``ccnl_core_addToCleanup``in ``ccnl_buf.h``

### Issues/PRs references
Fixes #302.
