### PR TITLE
removes redundant members from ccnl_content_s

### DIFF
--- a/src/ccnl-core/include/ccnl-content.h
+++ b/src/ccnl-core/include/ccnl-content.h
@@ -62,7 +62,6 @@ typedef struct ccnl_content_s {
     uint32_t last_used;                   /**< indicates when the stored content was last used */
 
 #ifdef USE_SUITE_NDNTLV
-    uint32_t freshnessperiod;             /**< defines how long a node has to wait (after the arrival of this data before) marking it “non-fresh”*/
     bool stale;                           /**< indicates if a packet was marked 'non-fresh' -> staled */
 #endif
 

--- a/src/ccnl-core/include/ccnl-content.h
+++ b/src/ccnl-core/include/ccnl-content.h
@@ -38,6 +38,7 @@ struct ccnl_prefix_s;
  * static or stale.
  */
 typedef enum ccnl_content_flags_e {
+    CCNL_CONTENT_FLAGS_NOT_STALE = 0x0, /**< content is not stale */
     CCNL_CONTENT_FLAGS_STATIC = 0x01,   /**< content is static */
     CCNL_CONTENT_FLAGS_STALE = 0x02,    /**< content is stale */
     CCNL_CONTENT_DO_NOT_USE = UINT8_MAX /**< for internal use only, sets the width of the enum to sizeof(uint8_t) */
@@ -54,17 +55,13 @@ typedef struct ccnl_content_s {
     struct ccnl_content_s *next;          /**< pointer to the next element in the content store */
     struct ccnl_content_s *prev;          /**< pointer to the previous element in the content store */
     struct ccnl_pkt_s *pkt;               /**< a byte representation of received content (the actual packet) */
+
     ccnl_content_flags flags;             /**< indicates if content is marked static or stale */
 
     // NON-CONFORM: "The [ContentSTore] MUST also implement the Staleness Bit."
     // >> CCNL: currently no stale bit, old content is fully removed <<
 
     uint32_t last_used;                   /**< indicates when the stored content was last used */
-
-#ifdef USE_SUITE_NDNTLV
-    bool stale;                           /**< indicates if a packet was marked 'non-fresh' -> staled */
-#endif
-
 #ifdef CCNL_RIOT
     evtimer_msg_event_t evtmsg_cstimeout; /**< event timer message which is triggered when a timeout in the content store occurs */
 #endif

--- a/src/ccnl-core/include/ccnl-pkt.h
+++ b/src/ccnl-core/include/ccnl-pkt.h
@@ -79,7 +79,7 @@ struct ccnl_pktdetail_ndntlv_s {
     struct ccnl_buf_s *ppkl;       /**< publisher public key locator */
     uint32_t interestlifetime;     /**< interest lifetime */
     /* Data */
-    uint32_t freshnessperiod;      /**< content freshness period */
+    uint32_t freshnessperiod;      /**< defines how long a node has to wait (after the arrival of this data before) marking it “non-fresh” */
 };
 
 struct ccnl_pkt_s {

--- a/src/ccnl-core/src/ccnl-content.c
+++ b/src/ccnl-core/src/ccnl-content.c
@@ -56,11 +56,7 @@ ccnl_content_new(struct ccnl_pkt_s **pkt)
     c->pkt = *pkt;
     *pkt = NULL;
     c->last_used = CCNL_NOW();
-#ifdef USE_SUITE_NDNTLV
-    if (c->pkt->suite == CCNL_SUITE_NDNTLV) {
-        c->stale = false;
-    }
-#endif
+    c->flags = CCNL_CONTENT_FLAGS_NOT_STALE;
 
     return c;
 }

--- a/src/ccnl-core/src/ccnl-content.c
+++ b/src/ccnl-core/src/ccnl-content.c
@@ -58,8 +58,6 @@ ccnl_content_new(struct ccnl_pkt_s **pkt)
     c->last_used = CCNL_NOW();
 #ifdef USE_SUITE_NDNTLV
     if (c->pkt->suite == CCNL_SUITE_NDNTLV) {
-        /* convert from milli seconds to seconds for now, as CCNL_NOW() has second granularity */
-        c->freshnessperiod = CCNL_NOW() + (c->pkt->s.ndntlv.freshnessperiod / 1000);
         c->stale = false;
     }
 #endif

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -738,7 +738,7 @@ ccnl_do_ageing(void *ptr, void *dummy)
 #ifdef USE_SUITE_NDNTLV
             if (c->pkt->suite == CCNL_SUITE_NDNTLV) {
                 if ((c->last_used + (c->pkt->s.ndntlv.freshnessperiod / 1000)) <= (uint32_t) t) {
-                    c->stale = true;
+                    c->flags |= CCNL_CONTENT_FLAGS_STALE;
                 }
             }
 #endif

--- a/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
@@ -319,7 +319,7 @@ ccnl_ndntlv_cMatch(struct ccnl_pkt_s *p, struct ccnl_content_s *c)
     if (!ccnl_i_prefixof_c(p->pfx, p->s.ndntlv.minsuffix, p->s.ndntlv.maxsuffix, c))
         return -1;
 
-    if (p->s.ndntlv.mbf && c->stale) {
+    if (p->s.ndntlv.mbf && ((c->flags & CCNL_CONTENT_FLAGS_STALE) != 0)) {
         DEBUGMSG(DEBUG, "ignore stale content\n");
         return -1;
     }


### PR DESCRIPTION
### Contribution description
This PR removes the members ``freshnessperiod`` and ``status`` from struct ``ccnl_content_s``. The freshness period indicates how long a node should wait after the arrival of the data packet before marking it “non-fresh”. The staleness is indicated in member ``stale`` in struct ``ccnl_content_s``. The actual check is performed in function ``ccnl_do_ageing(void *ptr, void *dummy)`` in file ``ccnl-relay.c``.
```C
 740  if ((c->last_used + (c->pkt->s.ndntlv.freshnessperiod / 1000)) <= (uint32_t) t) {
```
The member ``freshnessperiod`` of struct ``ccnl_content_s`` is never modified or used after it was initialized in ``ccnl_content_new``.

The member ``status`` is covered by member ``flags`` of type ``ccnl_content_flags``.

### Issues/PRs references
Fixes #304 