### PR TITLE
Fixed: Static content became stale in tutorial scenario 1

### DIFF
--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -737,7 +737,9 @@ ccnl_do_ageing(void *ptr, void *dummy)
         else {
 #ifdef USE_SUITE_NDNTLV
             if (c->pkt->suite == CCNL_SUITE_NDNTLV) {
-                if ((c->last_used + (c->pkt->s.ndntlv.freshnessperiod / 1000)) <= (uint32_t) t) {
+                // Mark content as stale if its freshness period expired and it is not static
+                if ((c->last_used + (c->pkt->s.ndntlv.freshnessperiod / 1000)) <= (uint32_t) t &&
+                        !(c->flags & CCNL_CONTENT_FLAGS_STATIC)) {
                     c->flags |= CCNL_CONTENT_FLAGS_STALE;
                 }
             }


### PR DESCRIPTION
### Contribution description

This PR fixes a bug in the ccnl-core component, more precisely in the ageing of the CS.

When following the instructions in scenario 1 in the tutorial, it was not possible to fetch the static content created in this tutorial. A inspection of the log revealed that the content was flagged as stale, despitebeing static. This PR adds an additional check in ``ccnl_relay:ccnl_do_ageing`` to prevent static content from being flagged as stale.
