### PR TITLE
introduces null checks for functions in ccnl-interest.c/refactoring

### DIFF
--- a/src/ccnl-core/include/ccnl-interest.h
+++ b/src/ccnl-core/include/ccnl-interest.h
@@ -2,8 +2,9 @@
  * @f ccnl-interest.h
  * @b CCN lite (CCNL), core header file (internal data structures)
  *
- * Copyright (C) 2011-17, University of Basel
- * Copyright (C) 2018 HAW Hamburg
+ * Copyright (C) 2011-17  University of Basel
+ * Copyright (C) 2018     HAW Hamburg
+ * Copyright (C) 2018     Safety IO
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -54,8 +55,10 @@ struct ccnl_interest_s {
 #endif
 };
 
-//struct ccnl_interest_s*
-//ccnl_interest_new(struct ccnl_face_s *from, struct ccnl_pkt_s **pkt);
+
+struct ccnl_interest_s*
+ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
+                  struct ccnl_pkt_s **pkt);
 
 int
 ccnl_interest_isSame(struct ccnl_interest_s *i, struct ccnl_pkt_s *pkt);

--- a/src/ccnl-core/include/ccnl-interest.h
+++ b/src/ccnl-core/include/ccnl-interest.h
@@ -33,7 +33,8 @@
 #endif
 
 /**
- * ?
+ * Defines if the forwarder should forward/retransmit a packet, otherwise it 
+ * will be handled internally.
  */
 #ifndef CCNL_PIT_COREPROPAGATES
 #define CCNL_PIT_COREPROPAGATES    0x01
@@ -44,7 +45,7 @@
  */
 struct ccnl_pendint_s { 
     struct ccnl_pendint_s *next; /**< pointer to the next list element */
-    struct ccnl_face_s *face;    /** */
+    struct ccnl_face_s *face;    /**< pointer to incoming face  */
     uint32_t last_used;          /** */
 };
 
@@ -60,7 +61,7 @@ struct ccnl_interest_s {
     unsigned short flags;               /**< ? */
     uint32_t lifetime;                  /**< interest lifetime */
     uint32_t last_used;                 /**< last time the entry was used */
-    int retries;                        /**< ? */
+    int retries;                        /**< current number of executed retransmits. */
 #ifdef CCNL_RIOT
     evtimer_msg_event_t evtmsg_retrans; /**< retransmission timer */
     evtimer_msg_event_t evtmsg_timeout; /**< timeout timer for (?) */
@@ -69,13 +70,13 @@ struct ccnl_interest_s {
 
 
 /**
- * ?
+ * Creates a new interest of type \ref ccnl_interest_s 
  * 
  * @param[in] ccnl
  * @param[in] from
  * @param[in] pkt
  *
- * @return 
+ * @return Upon success a new interest of type \ref ccnl_interest_s, otherwise NULL
  */
 struct ccnl_interest_s*
 ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,

--- a/src/ccnl-core/include/ccnl-interest.h
+++ b/src/ccnl-core/include/ccnl-interest.h
@@ -32,40 +32,94 @@
 #include "evtimer_msg.h"
 #endif
 
-struct ccnl_pendint_s { // pending interest
-    struct ccnl_pendint_s *next; // , *prev;
-    struct ccnl_face_s *face;
-    uint32_t last_used;
+/**
+ * ?
+ */
+#ifndef CCNL_PIT_COREPROPAGATES
+#define CCNL_PIT_COREPROPAGATES    0x01
+#endif
+
+/**
+ * @brief A pending interest linked list element
+ */
+struct ccnl_pendint_s { 
+    struct ccnl_pendint_s *next; /**< pointer to the next list element */
+    struct ccnl_face_s *face;    /** */
+    uint32_t last_used;          /** */
 };
 
+/**
+ * @brief A interest linked list element 
+ */
 struct ccnl_interest_s {
-    struct ccnl_interest_s *next, *prev;
-    struct ccnl_pkt_s *pkt;
-    struct ccnl_face_s *from;
-    struct ccnl_pendint_s *pending; // linked list of faces wanting that content
-    unsigned short flags;
-    uint32_t lifetime;
-#define CCNL_PIT_COREPROPAGATES    0x01
-#define CCNL_PIT_TRACED            0x02
-    uint32_t last_used;
-    int retries;
+    struct ccnl_interest_s *next;       /**< pointer to the next list element */
+    struct ccnl_interest_s *prev;       /**< pointer to the previous list element */
+    struct ccnl_pkt_s *pkt;             /**< the packet the interests originates from (?) */
+    struct ccnl_face_s *from;           /**< the face the interest was received from */
+    struct ccnl_pendint_s *pending;     /**< linked list of faces wanting that content */
+    unsigned short flags;               /**< ? */
+    uint32_t lifetime;                  /**< interest lifetime */
+    uint32_t last_used;                 /**< last time the entry was used */
+    int retries;                        /**< ? */
 #ifdef CCNL_RIOT
-    evtimer_msg_event_t evtmsg_retrans;
-    evtimer_msg_event_t evtmsg_timeout;
+    evtimer_msg_event_t evtmsg_retrans; /**< retransmission timer */
+    evtimer_msg_event_t evtmsg_timeout; /**< timeout timer for (?) */
 #endif
 };
 
 
+/**
+ * ?
+ * 
+ * @param[in] ccnl
+ * @param[in] from
+ * @param[in] pkt
+ *
+ * @return 
+ */
 struct ccnl_interest_s*
 ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
                   struct ccnl_pkt_s **pkt);
 
+/**
+ * Checks if two interests are the same
+ * 
+ * @param[in] i
+ * @param[in] pkt
+ *
+ * @return 0
+ * @return 1
+ * @return -1 if \ref i was NULL
+ * @return -2 if \ref pkt was NULL
+ */
 int
 ccnl_interest_isSame(struct ccnl_interest_s *i, struct ccnl_pkt_s *pkt);
 
+/**
+ * Adds a pending interest
+ * 
+ * @param[in] i
+ * @param[in] face
+ *
+ * @return 0
+ * @return 1
+ * @return -1 if \ref i was NULL
+ * @return -2 if \ref face was NULL
+ */
 int
 ccnl_interest_append_pending(struct ccnl_interest_s *i, struct ccnl_face_s *from);
 
+/**
+ * Removes a pending interest 
+ * 
+ * @param[in] i
+ * @param[in] face
+ *
+ * @return 0
+ * @return 1
+ * @return -1 if \ref i was NULL
+ * @return -2 if \ref face was NULL
+ */
 int
 ccnl_interest_remove_pending(struct ccnl_interest_s *i, struct ccnl_face_s *face);
 

--- a/src/ccnl-core/include/ccnl-relay.h
+++ b/src/ccnl-core/include/ccnl-relay.h
@@ -122,9 +122,6 @@ int
 ccnl_face_enqueue(struct ccnl_relay_s *ccnl, struct ccnl_face_s *to,
                  struct ccnl_buf_s *buf);
 
-struct ccnl_interest_s*
-ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
-                  struct ccnl_pkt_s **pkt);
 
 struct ccnl_interest_s*
 ccnl_interest_remove(struct ccnl_relay_s *ccnl, struct ccnl_interest_s *i);

--- a/src/ccnl-core/src/ccnl-interest.c
+++ b/src/ccnl-core/src/ccnl-interest.c
@@ -2,7 +2,8 @@
  * @f ccnl-interest.c
  * @b CCN lite (CCNL), core source file (internal data structures)
  *
- * Copyright (C) 2011-17, University of Basel
+ * Copyright (C) 2018    Safety IO 
+ * Copyright (C) 2011-18 University of Basel
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -66,32 +67,39 @@ ccnl_interest_new(struct ccnl_face_s *from, struct ccnl_pkt_s **pkt)
 int
 ccnl_interest_isSame(struct ccnl_interest_s *i, struct ccnl_pkt_s *pkt)
 {
-    if (i->pkt->pfx->suite != pkt->suite ||
-                ccnl_prefix_cmp(i->pkt->pfx, NULL, pkt->pfx, CMP_EXACT))
-        return 0;
+    if (i) {
+        if (pkt) {
+            if (i->pkt->pfx->suite != pkt->suite || ccnl_prefix_cmp(i->pkt->pfx, NULL, pkt->pfx, CMP_EXACT)) { 
+                return 0;
+            }
+            
+            switch (i->pkt->pfx->suite) {
+#ifdef USE_SUITE_CCNB
+                case CCNL_SUITE_CCNB: 
+                    return i->pkt->s.ccnb.minsuffix == pkt->s.ccnb.minsuffix && i->pkt->s.ccnb.maxsuffix == pkt->s.ccnb.maxsuffix &&
+                    ((!i->pkt->s.ccnb.ppkd && !pkt->s.ccnb.ppkd) || buf_equal(i->pkt->s.ccnb.ppkd, pkt->s.ccnb.ppkd));
+#endif
+                    
+#ifdef USE_SUITE_NDNTLV
+                case CCNL_SUITE_NDNTLV: 
+                    return i->pkt->s.ndntlv.minsuffix == pkt->s.ndntlv.minsuffix && i->pkt->s.ndntlv.maxsuffix == pkt->s.ndntlv.maxsuffix &&
+                    ((!i->pkt->s.ndntlv.ppkl && !pkt->s.ndntlv.ppkl) || buf_equal(i->pkt->s.ndntlv.ppkl, pkt->s.ndntlv.ppkl));
+#endif
+#ifdef USE_SUITE_CCNTLV 
+                case CCNL_SUITE_CCNTLV: 
+                    break;
+#endif
+                default:
+                    break;
+            }
+            
+            return 1;
+        }
 
-    switch (i->pkt->pfx->suite) {
-        #ifdef USE_SUITE_CCNB
-            case CCNL_SUITE_CCNB:
-                return i->pkt->s.ccnb.minsuffix == pkt->s.ccnb.minsuffix &&
-                    i->pkt->s.ccnb.maxsuffix == pkt->s.ccnb.maxsuffix &&
-                    ((!i->pkt->s.ccnb.ppkd && !pkt->s.ccnb.ppkd) ||
-                            buf_equal(i->pkt->s.ccnb.ppkd, pkt->s.ccnb.ppkd));
-        #endif
-        #ifdef USE_SUITE_NDNTLV
-            case CCNL_SUITE_NDNTLV:
-                return i->pkt->s.ndntlv.minsuffix == pkt->s.ndntlv.minsuffix &&
-                    i->pkt->s.ndntlv.maxsuffix == pkt->s.ndntlv.maxsuffix &&
-                    ((!i->pkt->s.ndntlv.ppkl && !pkt->s.ndntlv.ppkl) ||
-                    buf_equal(i->pkt->s.ndntlv.ppkl, pkt->s.ndntlv.ppkl));
-        #endif
-        #ifdef USE_SUITE_CCNTLV
-            case CCNL_SUITE_CCNTLV:
-        #endif
-            default:
-                break;
+        return -2;
     }
-    return 1;
+
+    return -1;
 }
 
 

--- a/src/ccnl-core/src/ccnl-interest.c
+++ b/src/ccnl-core/src/ccnl-interest.c
@@ -2,8 +2,8 @@
  * @f ccnl-interest.c
  * @b CCN lite (CCNL), core source file (internal data structures)
  *
- * Copyright (C) 2018    Safety IO 
  * Copyright (C) 2011-18 University of Basel
+ * Copyright (C) 2018    Safety IO 
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -23,46 +23,58 @@
 
 #ifndef CCNL_LINUXKERNEL
 #include "ccnl-interest.h"
+#include "ccnl-relay.h"
 #include "ccnl-malloc.h"
 #include "ccnl-os-time.h"
 #include "ccnl-prefix.h"
 #include "ccnl-logging.h"
+#include "ccnl-pkt-util.h"
 #else
+#include <ccnl-relay.h>
 #include <ccnl-interest.h>
 #include <ccnl-malloc.h>
 #include <ccnl-os-time.h>
 #include <ccnl-prefix.h>
 #include <ccnl-logging.h>
+#include <ccnl-pkt-util.h>
 #endif
 
 #ifdef CCNL_RIOT
 #include "ccn-lite-riot.h"
 #endif
 
-//FIXME: RELEAY FUNCTION MUST BE RENAMED!
-
-/*struct ccnl_interest_s*
-ccnl_interest_new(struct ccnl_face_s *from, struct ccnl_pkt_s **pkt)
+struct ccnl_interest_s*
+ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
+                  struct ccnl_pkt_s **pkt)
 {
+    char s[CCNL_MAX_PREFIX_SIZE];
+    (void) s;
+
     struct ccnl_interest_s *i = (struct ccnl_interest_s *) ccnl_calloc(1,
                                             sizeof(struct ccnl_interest_s));
-    char *s = NULL;
     DEBUGMSG_CORE(TRACE,
                   "ccnl_new_interest(prefix=%s, suite=%s)\n",
-                  (s = ccnl_prefix_to_path((*pkt)->pfx)),
+                  ccnl_prefix_to_str((*pkt)->pfx, s, CCNL_MAX_PREFIX_SIZE),
                   ccnl_suite2str((*pkt)->pfx->suite));
-    ccnl_free(s);
+
     if (!i)
         return NULL;
     i->pkt = *pkt;
+    /* currently, the aging function relies on seconds rather than on milli seconds */
+    i->lifetime = (*pkt)->s.ndntlv.interestlifetime / 1000;
     *pkt = NULL;
     i->flags |= CCNL_PIT_COREPROPAGATES;
     i->from = from;
     i->last_used = CCNL_NOW();
+    DBL_LINKED_LIST_ADD(ccnl->pit, i);
+
+#ifdef CCNL_RIOT
+    ccnl_evtimer_reset_interest_retrans(i);
+    ccnl_evtimer_reset_interest_timeout(i);
+#endif
 
     return i;
 }
-*/
 
 int
 ccnl_interest_isSame(struct ccnl_interest_s *i, struct ccnl_pkt_s *pkt)

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -319,38 +319,6 @@ ccnl_face_enqueue(struct ccnl_relay_s *ccnl, struct ccnl_face_s *to,
     return 0;
 }
 
-struct ccnl_interest_s*
-ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
-                  struct ccnl_pkt_s **pkt)
-{
-    char s[CCNL_MAX_PREFIX_SIZE];
-    (void) s;
-
-    struct ccnl_interest_s *i = (struct ccnl_interest_s *) ccnl_calloc(1,
-                                            sizeof(struct ccnl_interest_s));
-    DEBUGMSG_CORE(TRACE,
-                  "ccnl_new_interest(prefix=%s, suite=%s)\n",
-                  ccnl_prefix_to_str((*pkt)->pfx, s, CCNL_MAX_PREFIX_SIZE),
-                  ccnl_suite2str((*pkt)->pfx->suite));
-
-    if (!i)
-        return NULL;
-    i->pkt = *pkt;
-    /* currently, the aging function relies on seconds rather than on milli seconds */
-    i->lifetime = (*pkt)->s.ndntlv.interestlifetime / 1000;
-    *pkt = NULL;
-    i->flags |= CCNL_PIT_COREPROPAGATES;
-    i->from = from;
-    i->last_used = CCNL_NOW();
-    DBL_LINKED_LIST_ADD(ccnl->pit, i);
-
-#ifdef CCNL_RIOT
-    ccnl_evtimer_reset_interest_retrans(i);
-    ccnl_evtimer_reset_interest_timeout(i);
-#endif
-
-    return i;
-}
 
 struct ccnl_interest_s*
 ccnl_interest_remove(struct ccnl_relay_s *ccnl, struct ccnl_interest_s *i)

--- a/test/ccnl-core/CMakeLists.txt
+++ b/test/ccnl-core/CMakeLists.txt
@@ -10,7 +10,8 @@ link_directories(
 include_directories(include ../../src/ccnl-pkt/include ../../src/ccnl-fwd/include ../../src/ccnl-core/include ../../src/ccnl-unix/include)
 
 add_executable(test_interest test_interest.c)
-target_link_libraries(test_interest ccnl-core cmocka)
+target_link_libraries(test_interest ccnl-core ccnl-pkt cmocka)
+target_link_libraries(test_interest ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
 add_test(test_interest test_interest)
 
 add_executable(test_producer test_producer.c)
@@ -22,3 +23,8 @@ add_executable(test_prefix test_prefix.c)
 target_link_libraries(test_prefix ccnl-core ccnl-fwd ccnl-pkt ccnl-unix cmocka)
 target_link_libraries(test_prefix ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
 add_test(test_prefix test_prefix)
+
+#add_executable(test_prefix_bug test_prefix_bug.c)
+#target_link_libraries(test_prefix_bug ccnl-core ccnl-fwd ccnl-pkt ccnl-unix cmocka)
+#target_link_libraries(test_prefix_bug ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
+#add_test(test_prefix_bug test_prefix_bug)

--- a/test/ccnl-core/test_interest.c
+++ b/test/ccnl-core/test_interest.c
@@ -23,6 +23,17 @@
  
 #include "ccnl-interest.h"
 
+
+void test_ccnl_interest_append_pending_invalid_parameters()
+{
+    int result = ccnl_interest_append_pending(NULL, NULL);
+    assert_int_equal(result, -1); 
+
+    struct ccnl_interest_s interest;
+    result = ccnl_interest_append_pending(&interest, NULL);
+    assert_int_equal(result, -2); 
+}
+
 void test_ccnl_interest_is_same_invalid_parameters() 
 {
     int result = ccnl_interest_isSame(NULL, NULL);
@@ -55,6 +66,7 @@ int main(void)
     unit_test(test1),
     unit_test(test_ccnl_interest_is_same_invalid_parameters),
     unit_test(test_ccnl_interest_remove_pending_invalid_parameters),
+    unit_test(test_ccnl_interest_append_pending_invalid_parameters),
   };
  
   return run_tests(tests);

--- a/test/ccnl-core/test_interest.c
+++ b/test/ccnl-core/test_interest.c
@@ -1,10 +1,48 @@
+/**
+ * @file test-interest.c
+ * @brief CCN lite - Tests for interest functions
+ *
+ * Copyright (C) 2018 Safety IO
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
 #include <cmocka.h>
  
 #include "ccnl-interest.h"
- 
+
+void test_ccnl_interest_is_same_invalid_parameters() 
+{
+    int result = ccnl_interest_isSame(NULL, NULL);
+    assert_int_equal(result, -1); 
+
+    struct ccnl_interest_s interest;
+    result = ccnl_interest_isSame(&interest, NULL);
+    assert_int_equal(result, -2); 
+}
+
+void test_ccnl_interest_remove_pending_invalid_parameters()
+{
+    int result = ccnl_interest_remove_pending(NULL, NULL);
+    assert_int_equal(result, -1); 
+
+    struct ccnl_interest_s interest;
+    result = ccnl_interest_remove_pending(&interest, NULL);
+    assert_int_equal(result, -2); 
+}
+
 void test1()
 {
   int result = 0;
@@ -15,6 +53,8 @@ int main(void)
 {
   const UnitTest tests[] = {
     unit_test(test1),
+    unit_test(test_ccnl_interest_is_same_invalid_parameters),
+    unit_test(test_ccnl_interest_remove_pending_invalid_parameters),
   };
  
   return run_tests(tests);


### PR DESCRIPTION
### Contribution description

The PR introduces ``NULL`` checks for functions ``ccnl_interest_isSame`` and ``ccnl_interest_remove_pending``, and ``ccnl_interest_append_pending``  in ``ccnl-interest.c`` and the corresponding unit tests (for now just the failing functions). It also removes dead code from ccnl-interests.c (a function called ccnl_interest_new) and moves a function ``ccnl_interest_new`` from ``ccnl-relay.c``.

### Issues/PRs references

None