### PR TITLE
removes unused member flag from struct ccnl_interest_s

### DIFF
--- a/src/ccnl-core/include/ccnl-interest.h
+++ b/src/ccnl-core/include/ccnl-interest.h
@@ -33,14 +33,6 @@
 #endif
 
 /**
- * Defines if the forwarder should forward/retransmit a packet, otherwise it 
- * will be handled internally.
- */
-#ifndef CCNL_PIT_COREPROPAGATES
-#define CCNL_PIT_COREPROPAGATES    0x01
-#endif
-
-/**
  * @brief A pending interest linked list element
  */
 struct ccnl_pendint_s { 
@@ -58,7 +50,6 @@ struct ccnl_interest_s {
     struct ccnl_pkt_s *pkt;             /**< the packet the interests originates from (?) */
     struct ccnl_face_s *from;           /**< the face the interest was received from */
     struct ccnl_pendint_s *pending;     /**< linked list of faces wanting that content */
-    unsigned short flags;               /**< ? */
     uint32_t lifetime;                  /**< interest lifetime */
     uint32_t last_used;                 /**< last time the entry was used */
     int retries;                        /**< current number of executed retransmits. */

--- a/src/ccnl-core/src/ccnl-interest.c
+++ b/src/ccnl-core/src/ccnl-interest.c
@@ -63,7 +63,6 @@ ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
     /* currently, the aging function relies on seconds rather than on milli seconds */
     i->lifetime = (*pkt)->s.ndntlv.interestlifetime / 1000;
     *pkt = NULL;
-    i->flags |= CCNL_PIT_COREPROPAGATES;
     i->from = from;
     i->last_used = CCNL_NOW();
     DBL_LINKED_LIST_ADD(ccnl->pit, i);

--- a/src/ccnl-pkt/src/ccnl-pkt-builder.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-builder.c
@@ -144,7 +144,6 @@ ccnl_mkInterestObject(struct ccnl_prefix_s *name, ccnl_interest_opts_u *opts)
     i->pkt = (struct ccnl_pkt_s *) ccnl_calloc(1, sizeof(struct ccnl_pkt_s));
     i->pkt->buf = ccnl_mkSimpleInterest(name, opts);
     i->pkt->pfx = ccnl_prefix_dup(name);
-    i->flags |= CCNL_PIT_COREPROPAGATES;
     i->from = NULL;
     return i;
 }


### PR DESCRIPTION
### Contribution description
The member ``flag`` in ``ccnl_interest_s`` was used defined for the active interest object. A flag can define, if an interest is forwarded or should be handled internally (forwarded if last bit is set).

This field was previously used to mark an interest as "NFN-Interest" or "R2C-NFN-Interest". Since this is not required anymore, and "internal interests" were also used by NFN it can be removed.

### Issues/PRs references

This PR is related to a discussion in PR #307 