### PR TITLE
adds parameter check for ccnl_cmp2int

### DIFF
--- a/src/ccnl-core/include/ccnl-pkt-util.h
+++ b/src/ccnl-core/include/ccnl-pkt-util.h
@@ -1,7 +1,9 @@
 /*
  * @f ccnl-pkt-util.h
+ * @b Helper functions for identifying packets
  *
- * Copyright (C) 2011-15, University of Basel
+ * Copyright (C) 2011-18 University of Basel
+ * Copyright (C) 2018    Safety IO
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -14,15 +16,13 @@
  * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
- *
- * File history:
- * 2017-06-20 created
  */
 
 
 #ifndef CCNL_PKT_UTIL_H
 #define CCNL_PKT_UTIL_H
 
+#include <stddef.h>
 #include <stdbool.h>
 
 bool
@@ -40,7 +40,16 @@ ccnl_str2suite(char *cp);
 int
 ccnl_pkt2suite(unsigned char *data, int len, int *skip);
 
+/**
+ * Returns the integer representation of a string
+ *
+ * @param[in] cmp The string representation of a number
+ * @param[in] cmplen The length of the string
+ *
+ * @return Upon success returns the converted integral number as a long int value
+ * @return Upon failure the function returns 0 (e.g. if no valid conversion could be performed)
+ */
 int
-ccnl_cmp2int(unsigned char *cmp, int cmplen);
+ccnl_cmp2int(unsigned char *cmp, size_t cmplen);
 
 #endif

--- a/src/ccnl-core/src/ccnl-pkt-util.c
+++ b/src/ccnl-core/src/ccnl-pkt-util.c
@@ -185,17 +185,27 @@ ccnl_pkt2suite(unsigned char *data, int len, int *skip)
 }
 
 int
-ccnl_cmp2int(unsigned char *cmp, int cmplen)
+ccnl_cmp2int(unsigned char *cmp, size_t cmplen)
 {
-    long int i;
-    char *str = (char *)ccnl_malloc(cmplen+1);
-    DEBUGMSG(DEBUG, "  inter a: %i\n", cmplen);
-    DEBUGMSG(DEBUG, "  inter b\n");
-    memcpy(str, (char *)cmp, cmplen);
-    str[cmplen] = '\0';
-    DEBUGMSG(DEBUG, "  inter c: %s\n", str);
-    i = strtol(str, NULL, 0);
-    DEBUGMSG(DEBUG, "  inter d\n");
-    ccnl_free(str);
-    return (int)i;
+    if (cmp) {
+        long int i;
+        char *str = (char *)ccnl_malloc(cmplen+1);
+
+        DEBUGMSG(DEBUG, "  inter a: %zd\n", cmplen);
+        DEBUGMSG(DEBUG, "  inter b\n");
+
+        memcpy(str, (char *)cmp, cmplen);
+        str[cmplen] = '\0';
+        
+        DEBUGMSG(DEBUG, "  inter c: %s\n", str);
+        
+        i = strtol(str, NULL, 0);
+        
+        DEBUGMSG(DEBUG, "  inter d\n");
+
+        ccnl_free(str);
+        return (int)i;
+    }
+
+    return 0;
 }


### PR DESCRIPTION
### Contribution description

The function adds a ``NULL`` check for the first parameter of the function and also makes the second parameter of type ``size_t``.

### Issues/PRs references

Fixes #309 