### PR TITLE
adds tests for ccnl-sockunion.c

### DIFF
--- a/src/ccnl-core/src/ccnl-sockunion.c
+++ b/src/ccnl-core/src/ccnl-sockunion.c
@@ -195,24 +195,27 @@ ccnl_addr_cmp(sockunion *s1, sockunion *s2)
 char*
 ll2ascii(unsigned char *addr, size_t len)
 {
-    size_t i;
-    static char out[CCNL_LLADDR_STR_MAX_LEN + 1];
+    if (addr) {
+        size_t i;
+        static char out[CCNL_LLADDR_STR_MAX_LEN + 1] = { 0 };
 
-    out[0] = '\0';
+        out[0] = '\0';
 
-    for (i = 0; i < len; i++) {
-        out[(3 * i)] = _half_byte_to_char(addr[i] >> 4);
-        out[(3 * i) + 1] = _half_byte_to_char(addr[i] & 0xf);
+        for (i = 0; i < len; i++) {
+            out[(3 * i)] = _half_byte_to_char(addr[i] >> 4);
+            out[(3 * i) + 1] = _half_byte_to_char(addr[i] & 0xf);
 
-        if (i != (len - 1)) {
-            out[(3 * i) + 2] = ':';
+            if (i != (len - 1)) {
+                out[(3 * i) + 2] = ':';
+            } else {
+                out[(3 * i) + 2] = '\0';
+            }
         }
-        else {
-            out[(3 * i) + 2] = '\0';
-        }
+
+        return out;
     }
 
-    return out;
+    return NULL;
 }
 
 char

--- a/test/ccnl-core/CMakeLists.txt
+++ b/test/ccnl-core/CMakeLists.txt
@@ -4,6 +4,12 @@ project(ccnl-core-tests)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/test/ccnl-core)
 
+set(CCNL_EXTRA_FLAGS
+        -DUSE_IPV4
+        -DUSE_IPV6
+    )
+add_definitions(${CCNL_EXTRA_FLAGS})
+
 link_directories(
     ${CMAKE_BINARY_DIR}/lib
 )
@@ -13,6 +19,11 @@ add_executable(test_interest test_interest.c)
 target_link_libraries(test_interest ccnl-core ccnl-pkt cmocka)
 target_link_libraries(test_interest ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
 add_test(test_interest test_interest)
+
+add_executable(test_sockunion test_sockunion.c)
+target_link_libraries(test_sockunion ccnl-core cmocka)
+target_link_libraries(test_sockunion${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
+add_test(test_sockunion test_sockunion)
 
 add_executable(test_producer test_producer.c)
 target_link_libraries(test_producer ccnl-core cmocka)

--- a/test/ccnl-core/test_sockunion.c
+++ b/test/ccnl-core/test_sockunion.c
@@ -1,0 +1,105 @@
+/**
+ * @file test-sockunion.c
+ * @brief Tests for sockunion related functions
+ *
+ * Copyright (C) 2018 Safety IO
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+ 
+#include "ccnl-sockunion.h"
+
+void test_ll2ascii_invalid()
+{
+    char *result = ll2ascii(NULL, 1);
+    assert_true(result == NULL);
+}
+
+void test_ll2ascii_valid()
+{
+    const char *address = "ffffffffffff";
+    char *result = ll2ascii((unsigned char*)address, 6);
+    assert_true(result != NULL);
+    // shouldn't it be ff:ff:ff:ff:ff:ff?
+    assert_true(memcmp("66:66:66:66:66:66", result, 17) == 0);
+}
+
+void test_half_byte_to_char() 
+{
+    uint8_t half_byte = 9;
+    char result = _half_byte_to_char(half_byte);
+    assert_true(result == '9');
+
+    half_byte = 11;
+    result = _half_byte_to_char(half_byte);
+    assert_true(result == ('a' + 1));
+}
+    
+void test_ccnl_is_local_addr_invalid() 
+{
+    int result = ccnl_is_local_addr(NULL);
+    assert_int_equal(result, 0);
+}
+
+void test_ccnl_is_local_addr_valid() 
+{
+    sockunion socket;
+    socket.sa.sa_family = AF_UNIX;
+    int result = ccnl_is_local_addr(&socket);
+    assert_int_equal(result, -1);
+
+    /** test for socket type ipv4 */
+    socket.sa.sa_family = AF_INET;
+    socket.ip4.sin_addr.s_addr = htonl(0x7f000001);
+    result = ccnl_is_local_addr(&socket);
+    assert_int_equal(result, 1);
+
+    /** test for socket type ipv6 with given ipv4 loopback */
+    socket.sa.sa_family = AF_INET6;
+    unsigned char ipv4_loopback[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0x7f, 0, 0, 1 };
+    memcpy((socket.ip6.sin6_addr.s6_addr), ipv4_loopback, 16);
+    result = ccnl_is_local_addr(&socket);
+    assert_int_equal(result, 1);
+    unsigned char ipv6_loopback[] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 };
+    memcpy(socket.ip6.sin6_addr.s6_addr, ipv6_loopback, 16);
+    /** test for socket type ipv6 with ipv6 loopback */
+    result = ccnl_is_local_addr(&socket);
+    assert_int_equal(result, 1);
+}
+
+void test_ccnl_addr2ascii_invalid()
+{
+    char *result = ccnl_addr2ascii(NULL);
+    assert_string_equal(result, "(local)");
+}
+
+int main(void)
+{
+    const UnitTest tests[] = {
+        unit_test(test_half_byte_to_char),
+        unit_test(test_ll2ascii_invalid),
+        unit_test(test_ll2ascii_valid),
+        unit_test(test_ccnl_is_local_addr_invalid),
+        unit_test(test_ccnl_is_local_addr_valid),
+        unit_test(test_ccnl_addr2ascii_invalid),
+    };
+    
+    return run_tests(tests);
+}
+


### PR DESCRIPTION
### Contribution description
Introduces some unit tests for  ccnl-sockunion.{c,h}. The PR lacks support for ``ccnl_addr2ascii`` and ``ccnl_addr_cmp``. This is mostly due to the fact that some ifdef statements include/exclude parts of the functions. Hence, the tests need to be split up and build files need to changed. 