### PR TITLE
adds ccnl_free call in ccnl_pkt_dup

### DIFF
--- a/src/ccnl-core/src/ccnl-pkt.c
+++ b/src/ccnl-core/src/ccnl-pkt.c
@@ -74,6 +74,9 @@ struct ccnl_pkt_s *
 ccnl_pkt_dup(struct ccnl_pkt_s *pkt){
     struct ccnl_pkt_s * ret = ccnl_malloc(sizeof(struct ccnl_pkt_s));
     if(!pkt){
+        if (ret) {
+            ccnl_free(ret);
+        }
         return NULL;
     }
     if(!ret){


### PR DESCRIPTION
### Contribution description
Adds a ``ccnl_free`` call to ``ccnl_pkt_dup`` in case NULL was passed to the function. For further details have a look at #316 

### Issues/PRs references
Fixes #316 