### PR TITLE
adds unit tests for ccnl-content.c

### DIFF
--- a/src/ccnl-core/include/ccnl-content.h
+++ b/src/ccnl-core/include/ccnl-content.h
@@ -86,7 +86,7 @@ ccnl_content_new(struct ccnl_pkt_s **packet);
 
  * @param[in] content The content object which will be freed 
  */
-void
+int
 ccnl_content_free(struct ccnl_content_s *content);
 
 #endif // EOF

--- a/src/ccnl-core/src/ccnl-content.c
+++ b/src/ccnl-core/src/ccnl-content.c
@@ -41,6 +41,10 @@
 struct ccnl_content_s*
 ccnl_content_new(struct ccnl_pkt_s **pkt)
 {
+    if (!pkt) {
+        return NULL;
+    }
+
     struct ccnl_content_s *c;
 
     char s[CCNL_MAX_PREFIX_SIZE];

--- a/src/ccnl-core/src/ccnl-content.c
+++ b/src/ccnl-core/src/ccnl-content.c
@@ -61,9 +61,18 @@ ccnl_content_new(struct ccnl_pkt_s **pkt)
     return c;
 }
 
-void
+int 
 ccnl_content_free(struct ccnl_content_s *content) 
 {
-    ccnl_pkt_free(content->pkt);
-    ccnl_free(content);
+    if (content) {
+        if (content->pkt) {
+            ccnl_pkt_free(content->pkt);
+        }
+        
+        ccnl_free(content);
+
+        return 0;
+    }
+
+    return -1;
 }

--- a/test/ccnl-core/CMakeLists.txt
+++ b/test/ccnl-core/CMakeLists.txt
@@ -35,12 +35,12 @@ target_link_libraries(test_pkt-util ccnl-core ccnl-pkt ccnl-fwd cmocka)
 target_link_libraries(test_pkt-util ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
 add_test(test_pkt-util test_pkt-util)
 
+add_executable(test_content test_content.c)
+target_link_libraries(test_content ccnl-core ccnl-pkt cmocka)
+target_link_libraries(test_content ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
+add_test(test_content test_content)
+
 add_executable(test_prefix test_prefix.c)
 target_link_libraries(test_prefix ccnl-core ccnl-fwd ccnl-pkt ccnl-unix cmocka)
 target_link_libraries(test_prefix ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
 add_test(test_prefix test_prefix)
-
-#add_executable(test_prefix_bug test_prefix_bug.c)
-#target_link_libraries(test_prefix_bug ccnl-core ccnl-fwd ccnl-pkt ccnl-unix cmocka)
-#target_link_libraries(test_prefix_bug ${PROJECT_LINK_LIBS} ${EXT_LINK_LIBS} ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
-#add_test(test_prefix_bug test_prefix_bug)

--- a/test/ccnl-core/test_content.c
+++ b/test/ccnl-core/test_content.c
@@ -1,0 +1,41 @@
+/**
+ * @file test_content.c
+ * @brief Tests for content functions
+ *
+ * Copyright (C) 2018 Safety IO
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+ 
+#include "ccnl-content.h"
+
+void test_ccnl_content_free_invalid() 
+{
+    int result = ccnl_content_free(NULL); 
+    assert_int_equal(result, -1);
+}
+
+
+
+int main(void)
+{
+    const UnitTest tests[] = {
+        unit_test(test_ccnl_content_free_invalid),
+    };
+    
+    return run_tests(tests);
+}


### PR DESCRIPTION
### Contribution description
Adds unit tests for functions defined in ``ccnl-content.c``, also adds ``NULL`` checks so the function returns immediately if an invalid argument is passed to the function.