### PR TITLE
addresses dead assignments in ccn-lite-mkI/introduces error checks to ccn-lite-ctrl

### DIFF
--- a/src/ccnl-utils/src/ccn-lite-ctrl.c
+++ b/src/ccnl-utils/src/ccn-lite-ctrl.c
@@ -1304,11 +1304,16 @@ help:
 
             //receive request
             memset(out, 0, sizeof(out));
-            if (!use_udp)
-                len = recv(sock, out, sizeof(out), 0);
-            else
-                len = recvfrom(sock, out, sizeof(out), 0,
-                               (struct sockaddr *)&si, &slen);
+            if (!use_udp) {
+                if ((len = recv(sock, out, sizeof(out), 0)) == -1) {
+                    DEBUGMSG(ERROR, "an error occurred on receiving data\n"); 
+                }
+            } else {
+                if ((len = recvfrom(sock, out, sizeof(out), 0,
+                               (struct sockaddr *)&si, &slen)) == -1) {
+                    DEBUGMSG(ERROR, "an error occurred on receiving data\n"); 
+                }
+            }
 
             //send file
             if (!use_udp)

--- a/src/ccnl-utils/src/ccn-lite-mkI.c
+++ b/src/ccnl-utils/src/ccn-lite-mkI.c
@@ -28,7 +28,7 @@ int
 main(int argc, char *argv[])
 {
 
-    char *minSuffix = 0, *maxSuffix = 0, *scope = 0;
+    char *minSuffix = 0, *scope = 0;
     char *digest = 0, *publisher = 0;
     char *fname = 0;
     int f, opt;
@@ -42,14 +42,13 @@ main(int argc, char *argv[])
     ccnl_interest_opts_u int_opts;
 
     (void) minSuffix;
-    (void) maxSuffix;
     (void) scope;
 
     time(&curtime);
     // Get current time in double to avoid dealing with time_t
     nonce = (uint32_t) difftime(curtime, 0);
 
-    while ((opt = getopt(argc, argv, "ha:c:d:e:i:ln:o:p:s:v:x:")) != -1) {
+    while ((opt = getopt(argc, argv, "ha:c:d:e:i:ln:o:p:s:v:")) != -1) {
         switch (opt) {
         case 'a':
             minSuffix = optarg;
@@ -96,9 +95,6 @@ main(int argc, char *argv[])
                 debug_level = ccnl_debug_str2level(optarg);
 #endif
             break;
-        case 'x':
-            maxSuffix = optarg;
-            break;
         case 's':
             packettype = ccnl_str2suite(optarg);
             if (packettype >= 0 && packettype < CCNL_SUITE_LAST)
@@ -122,7 +118,6 @@ Usage:
 #ifdef USE_LOGGING
             "  -v DEBUG_LEVEL (fatal, error, warning, info, debug, verbose, trace)\n"
 #endif
-            "  -x LEN     maX additional components\n",
             argv[0]);
             exit(1);
         }

--- a/src/ccnl-utils/src/ccn-lite-mkI.c
+++ b/src/ccnl-utils/src/ccn-lite-mkI.c
@@ -2,7 +2,7 @@
  * @f util/ccn-lite-mkI.c
  * @b CLI mkInterest, write to Stdout
  *
- * Copyright (C) 2013-15, Christian Tschudin, University of Basel
+ * Copyright (C) 2013-18, Christian Tschudin, University of Basel
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -16,8 +16,6 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *
- * File history:
- * 2013-07-06  created
  */
 
 #include "ccnl-common.h"
@@ -28,7 +26,6 @@ int
 main(int argc, char *argv[])
 {
 
-    char *minSuffix = 0;
     char *digest = 0, *publisher = 0;
     char *fname = 0;
     int f, opt;
@@ -41,17 +38,12 @@ main(int argc, char *argv[])
     unsigned int chunknum = UINT_MAX;
     ccnl_interest_opts_u int_opts;
 
-    (void) minSuffix;
-
     time(&curtime);
     // Get current time in double to avoid dealing with time_t
     nonce = (uint32_t) difftime(curtime, 0);
 
-    while ((opt = getopt(argc, argv, "ha:d:e:i:ln:o:p:s:v:")) != -1) {
+    while ((opt = getopt(argc, argv, "hd:e:i:ln:o:p:s:v:")) != -1) {
         switch (opt) {
-        case 'a':
-            minSuffix = optarg;
-            break;
         case 'd':
             digest = optarg;
             dlen = unescape_component(digest);
@@ -101,17 +93,16 @@ main(int argc, char *argv[])
         default:
 Usage:
             fprintf(stderr, "usage: %s [options] URI\n"
-            "  -a LEN     miN additional components\n"
             "  -d DIGEST  content digest (sets -x to 0)\n"
             "  -e NONCE   random 4 bytes\n"
             "  -l         URI is a Lambda expression\n"
             "  -n CHUNKNUM positive integer for chunk interest\n"
             "  -o FNAME   output file (instead of stdout)\n"
             "  -p DIGEST  publisher fingerprint\n"
-            "  -s SUITE   (ccnb, ccnx2015, ndn2013)\n"
 #ifdef USE_LOGGING
             "  -v DEBUG_LEVEL (fatal, error, warning, info, debug, verbose, trace)\n"
 #endif
+            "  -s SUITE   (ccnb, ccnx2015, ndn2013)\n",
             argv[0]);
             exit(1);
         }

--- a/src/ccnl-utils/src/ccn-lite-mkI.c
+++ b/src/ccnl-utils/src/ccn-lite-mkI.c
@@ -28,7 +28,7 @@ int
 main(int argc, char *argv[])
 {
 
-    char *minSuffix = 0, *scope = 0;
+    char *minSuffix = 0;
     char *digest = 0, *publisher = 0;
     char *fname = 0;
     int f, opt;
@@ -42,19 +42,15 @@ main(int argc, char *argv[])
     ccnl_interest_opts_u int_opts;
 
     (void) minSuffix;
-    (void) scope;
 
     time(&curtime);
     // Get current time in double to avoid dealing with time_t
     nonce = (uint32_t) difftime(curtime, 0);
 
-    while ((opt = getopt(argc, argv, "ha:c:d:e:i:ln:o:p:s:v:")) != -1) {
+    while ((opt = getopt(argc, argv, "ha:d:e:i:ln:o:p:s:v:")) != -1) {
         switch (opt) {
         case 'a':
             minSuffix = optarg;
-            break;
-        case 'c':
-            scope = optarg;
             break;
         case 'd':
             digest = optarg;
@@ -106,8 +102,6 @@ main(int argc, char *argv[])
 Usage:
             fprintf(stderr, "usage: %s [options] URI\n"
             "  -a LEN     miN additional components\n"
-            "  -c SCOPE\n"
-
             "  -d DIGEST  content digest (sets -x to 0)\n"
             "  -e NONCE   random 4 bytes\n"
             "  -l         URI is a Lambda expression\n"


### PR DESCRIPTION
### Contribution description

Addresses dead assignments identified by the ``scan-build.sh`` script in the top-level directory. It removes the ``-a``, ``-x``,  and ``-c`` command line option from the ``ccn-lite-mkI`` (the values passed via the command line are never read). 

