### PR TITLE
replaced calls to atof with strtof

### DIFF
--- a/src/ccnl-utils/src/ccn-lite-fetch.c
+++ b/src/ccnl-utils/src/ccn-lite-fetch.c
@@ -199,7 +199,7 @@ main(int argc, char *argv[])
             udp = optarg;
             break;
         case 'w':
-            wait = atof(optarg);
+            wait = (float)strtof(optarg, (char**) NULL);
             break;
             case 'v':
 #ifdef USE_LOGGING

--- a/src/ccnl-utils/src/ccn-lite-peek.c
+++ b/src/ccnl-utils/src/ccn-lite-peek.c
@@ -81,7 +81,7 @@ main(int argc, char *argv[])
 #endif
             break;
         case 'w':
-            wait = atof(optarg);
+            wait = (float)strtof(optarg, (char**) NULL);
             break;
         case 'x':
             ux = optarg;

--- a/src/ccnl-utils/src/ccn-lite-peekcomputation.c
+++ b/src/ccnl-utils/src/ccn-lite-peekcomputation.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv){
         udp = optarg;
         break;
         case 'w':
-        wait = atof(optarg);
+        wait = (float)strtof(optarg, (char**) NULL);
         break;
         case 'x':
         ux = optarg;

--- a/src/ccnl-utils/src/ccn-lite-rpc.c
+++ b/src/ccnl-utils/src/ccn-lite-rpc.c
@@ -317,7 +317,7 @@ main(int argc, char *argv[])
 #endif
             break;
         case 'w':
-            wait = atof(optarg);
+            wait = (float)strtof(optarg, (char**) NULL);
             break;
         case 'x':
             ux = optarg;

--- a/src/ccnl-utils/src/ccn-lite-simplenfn.c
+++ b/src/ccnl-utils/src/ccn-lite-simplenfn.c
@@ -131,7 +131,7 @@ main(int argc, char *argv[])
 #endif
             break;
         case 'w':
-            wait = atof(optarg);
+            wait = (float)strtof(optarg, (char**) NULL);
             break;
         case 'x':
             ux = optarg;


### PR DESCRIPTION
### Contribution description
Replaces calls to ``atof`` with ``strtof`` as described in #319. On a side note the previous PR #322 had a commit which was part of #321. This is a new PR which just has one single commit covering the atof/strtof replacement.

### Issues/PRs references
Addresses #319. See also #321 . 