### PR TITLE
Fixed ccnb pktdump

### DIFF
--- a/src/ccnl-utils/src/ccn-lite-pktdump.c
+++ b/src/ccnl-utils/src/ccn-lite-pktdump.c
@@ -116,10 +116,10 @@ ccnb_deheadAndPrint(int lev, unsigned char *base, unsigned char **buf,
         fprintf(out, "%04zx  ", *buf - base);
     }
 
-    for (i = 0; i < lev; i++) {
-        fprintf(out, "  ");
-    }
     if (**buf == 0) {
+        for (i = 0; lev > 0 && i < lev - 1; i++) {
+            fprintf(out, "  ");
+        }
         if (!rawxml) {
             fprintf(out, "00 ");
         }
@@ -127,6 +127,9 @@ ccnb_deheadAndPrint(int lev, unsigned char *base, unsigned char **buf,
         *buf += 1;
         *len -= 1;
         return 0;
+    }
+    for (i = 0; i < lev; i++) {
+        fprintf(out, "  ");
     }
     for (i = 0; i < (int)sizeof(i) && i < *len; i++) {
         unsigned char c = (*buf)[i];

--- a/src/ccnl-utils/src/ccn-lite-pktdump.c
+++ b/src/ccnl-utils/src/ccn-lite-pktdump.c
@@ -225,10 +225,12 @@ ccnb_parse_lev(int lev, unsigned char *base, unsigned char **buf,
     char *next_tag;
 
     while (ccnb_deheadAndPrint(lev, base, buf, len, &num, &typ, rawxml, out) == 0) {
-        if (num > *len) return 0;
         switch (typ) {
         case CCN_TT_BLOB:
         case CCN_TT_UDATA:
+            if (num > *len) {
+                return 0;
+            }
             if (rawxml) {
                 fprintf(out, "<data ");
                 fprintf(out, "size=\"%i\" dt=\"binary.base64\"", num);


### PR DESCRIPTION
<!--
Before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the CCN-lite
coding conventions, see https://github.com/cn-uofbasel/ccn-lite/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the pktdump utility for the ccnb suite:
- pktdump would interpret a DTAG value as a length and terminate prematurely if the dtag value exceeded the length of the packet.
- Closing tags were wrongly indented.

<!--
Put here the description of your contribution:
- describe which part(s) of CCN-lite is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Fixes #325.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
