### PR TITLE
changes type of length in struct ccnl_buf_s

### DIFF
--- a/src/ccnl-core/include/ccnl-buf.h
+++ b/src/ccnl-core/include/ccnl-buf.h
@@ -30,7 +30,7 @@ struct ccnl_relay_s;
 
 struct ccnl_buf_s {
     struct ccnl_buf_s *next;
-    ssize_t datalen;
+    size_t datalen;
     unsigned char data[1];
 };
 
@@ -38,7 +38,7 @@ struct ccnl_buf_s {
  * 
  */
 struct ccnl_buf_s*
-ccnl_buf_new(void *data, int len);
+ccnl_buf_new(void *data, size_t len);
 
 #define buf_dup(B)      (B) ? ccnl_buf_new(B->data, B->datalen) : NULL
 #define buf_equal(X,Y)  ((X) && (Y) && (X->datalen==Y->datalen) &&\

--- a/src/ccnl-core/src/ccnl-buf.c
+++ b/src/ccnl-core/src/ccnl-buf.c
@@ -40,7 +40,7 @@
 #endif
 
 struct ccnl_buf_s*
-ccnl_buf_new(void *data, int len)
+ccnl_buf_new(void *data, size_t len)
 {
     struct ccnl_buf_s *b = (struct ccnl_buf_s*) ccnl_malloc(sizeof(*b) + len);
 

--- a/src/ccnl-core/src/ccnl-dump.c
+++ b/src/ccnl-core/src/ccnl-dump.c
@@ -45,9 +45,8 @@ static void
 blob(struct ccnl_buf_s *buf)
 {
     unsigned char *cp = buf->data;
-    int i;
 
-    for (i = 0; i < buf->datalen; i++, cp++)
+    for (size_t i = 0; i < buf->datalen; i++, cp++)
         CONSOLE("%02x", *cp);
 }
 

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -184,7 +184,7 @@ ccnl_interface_enqueue(void (tx_done)(void*, int, int), struct ccnl_face_s *f,
         if (buf) { 
             DEBUGMSG_CORE(TRACE, "enqueue interface=%p buf=%p len=%zd (qlen=%d)\n",
                   (void*)ifc, (void*)buf,
-                  buf ? buf->datalen : -1, ifc ? ifc->qlen : -1);
+                  buf ? buf->datalen : 0, ifc ? ifc->qlen : -1);
         }
 
         if (ifc->qlen >= CCNL_MAX_IF_QLEN) {
@@ -288,7 +288,7 @@ ccnl_face_enqueue(struct ccnl_relay_s *ccnl, struct ccnl_face_s *to,
         return -1;
     }
     DEBUGMSG_CORE(TRACE, "enqueue face=%p (id=%d.%d) buf=%p len=%zd\n",
-             (void*) to, ccnl->id, to->faceid, (void*) buf, buf ? buf->datalen : -1);
+             (void*) to, ccnl->id, to->faceid, (void*) buf, buf ? buf->datalen : 0);
 
     for (msg = to->outq; msg; msg = msg->next) // already in the queue?
         if (buf_equal(msg, buf)) {

--- a/src/ccnl-utils/src/ccn-lite-pktdump.c
+++ b/src/ccnl-utils/src/ccn-lite-pktdump.c
@@ -116,10 +116,10 @@ ccnb_deheadAndPrint(int lev, unsigned char *base, unsigned char **buf,
         fprintf(out, "%04zx  ", *buf - base);
     }
 
-    for (i = 0; i < lev; i++) {
-        fprintf(out, "  ");
-    }
     if (**buf == 0) {
+        for (i = 0; lev > 0 && i < lev - 1; i++) {
+            fprintf(out, "  ");
+        }
         if (!rawxml) {
             fprintf(out, "00 ");
         }
@@ -127,6 +127,9 @@ ccnb_deheadAndPrint(int lev, unsigned char *base, unsigned char **buf,
         *buf += 1;
         *len -= 1;
         return 0;
+    }
+    for (i = 0; i < lev; i++) {
+        fprintf(out, "  ");
     }
     for (i = 0; i < (int)sizeof(i) && i < *len; i++) {
         unsigned char c = (*buf)[i];

--- a/src/ccnl-utils/src/ccn-lite-pktdump.c
+++ b/src/ccnl-utils/src/ccn-lite-pktdump.c
@@ -225,10 +225,12 @@ ccnb_parse_lev(int lev, unsigned char *base, unsigned char **buf,
     char *next_tag;
 
     while (ccnb_deheadAndPrint(lev, base, buf, len, &num, &typ, rawxml, out) == 0) {
-        if (num > *len) return 0;
         switch (typ) {
         case CCN_TT_BLOB:
         case CCN_TT_UDATA:
+            if (num > *len) {
+                return 0;
+            }
             if (rawxml) {
                 fprintf(out, "<data ");
                 fprintf(out, "size=\"%i\" dt=\"binary.base64\"", num);


### PR DESCRIPTION
### Contribution description
Changes the type of  member``data_len`` in ``struct ccnl_buf_s`` from ``ssize_t`` to ``size_t``. This PR also changes the length parameter of ``ccnl_buf_new`` from ``int`` to ``size_t``.


### Issues/PRs references
Fixes #330 