### PR TITLE
minor cleanup in ccn-lite-mkC.c and test_sockunion.c

### DIFF
--- a/src/ccnl-utils/src/ccn-lite-mkC.c
+++ b/src/ccnl-utils/src/ccn-lite-mkC.c
@@ -28,6 +28,13 @@
 #include "ccnl-pkt-ndntlv.h"
 #include "ccnl-ext-hmac.h"
 
+#ifndef CCN_LITE_MKC_OUT_SIZE
+#define CCN_LITE_MKC_OUT_SIZE (65 * 1024)
+#endif
+
+#ifndef CCN_LITE_MKC_BODY_SIZE
+#define CCN_LITE_MKC_BODY_SIZE (64 * 1024)
+#endif
 
 // ----------------------------------------------------------------------
 
@@ -39,9 +46,9 @@ char *witness;
 int
 main(int argc, char *argv[])
 {
-    unsigned char body[64*1024];
-    unsigned char out[65*1024];
-    unsigned char *publisher = out;
+    unsigned char body[CCN_LITE_MKC_BODY_SIZE];
+    unsigned char out[CCN_LITE_MKC_OUT_SIZE];
+    unsigned char *publisher = NULL;
     char *infname = 0, *outfname = 0;
     unsigned int chunknum = UINT_MAX, lastchunknum = UINT_MAX;
     int f, len, opt, plen, offs = 0;
@@ -49,16 +56,13 @@ main(int argc, char *argv[])
     struct ccnl_prefix_s *name;
     int suite = CCNL_SUITE_DEFAULT;
     struct key_s *keys = NULL;
-    struct ccnl_prefix_s *prefix;
-    struct ccnl_buf_s *buf;
     ccnl_data_opts_u data_opts;
-    (void)prefix;
-    (void)buf;
-    (void) contentpos;
+
+    (void)contentpos;
     (void)keys;
     (void)lastchunknum;
     (void)chunknum;
-    (void) data_opts;
+    (void)data_opts;
 
     while ((opt = getopt(argc, argv, "hg:i:k:l:n:o:p:s:v:w:")) != -1) {
         switch (opt) {

--- a/test/ccnl-core/test_sockunion.c
+++ b/test/ccnl-core/test_sockunion.c
@@ -36,8 +36,16 @@ void test_ll2ascii_valid()
     const char *address = "ffffffffffff";
     char *result = ll2ascii((unsigned char*)address, 6);
     assert_true(result != NULL);
-    // shouldn't it be ff:ff:ff:ff:ff:ff?
-    assert_true(memcmp("66:66:66:66:66:66", result, 17) == 0);
+
+    /**
+     * The test will actually fail at the above "assert_true" statement if 'result'
+     * is null - however, the static code analyzer of LLVM does not recognize this
+     * behavior, hence, the actual check if 'result' is not NULL
+     */
+    if (result) { 
+        // shouldn't it be ff:ff:ff:ff:ff:ff? 
+         assert_true(memcmp("66:66:66:66:66:66", result, 17) == 0);
+    }
 }
 
 void test_half_byte_to_char() 


### PR DESCRIPTION
### Contribution description
The PR addresses a few minor issues identified by the ``scan-build.sh`` script. It removes non necessary ``(void)variable`` statements for potentially unused variables and clarifies a 'non-null' warning caused by LLVMs static code analyzer.