### PR TITLE
adds check on length in ll2ascii()

### DIFF
--- a/src/ccnl-core/src/ccnl-sockunion.c
+++ b/src/ccnl-core/src/ccnl-sockunion.c
@@ -195,7 +195,7 @@ ccnl_addr_cmp(sockunion *s1, sockunion *s2)
 char*
 ll2ascii(unsigned char *addr, size_t len)
 {
-    if (addr) {
+    if ((len <= CCNL_LLADDR_STR_MAX_LEN) && (addr)) {
         size_t i;
         static char out[CCNL_LLADDR_STR_MAX_LEN + 1] = { 0 };
 

--- a/test/ccnl-core/test_sockunion.c
+++ b/test/ccnl-core/test_sockunion.c
@@ -29,6 +29,11 @@ void test_ll2ascii_invalid()
 {
     char *result = ll2ascii(NULL, 1);
     assert_true(result == NULL);
+
+    const char *address = "deadbeef";
+    /** size (second parameter) should be larger than the array which stores the result (in order to fail) */
+    result = ll2ascii(NULL, CCNL_LLADDR_STR_MAX_LEN + 1);
+    assert_true(result == NULL);
 }
 
 void test_ll2ascii_valid()
@@ -43,20 +48,25 @@ void test_ll2ascii_valid()
      * behavior, hence, the actual check if 'result' is not NULL
      */
     if (result) { 
-        // shouldn't it be ff:ff:ff:ff:ff:ff? 
-         assert_true(memcmp("66:66:66:66:66:66", result, 17) == 0);
+        /**
+         * This caused some confusion, but "f" is a numerical 102 in ASCII and
+         * (102 >> 4) => 6 and (also 102 & 0xF) => 6, so the result is '66'. Writing
+         * something alike "fff...fff" in order to retrieve "ff:ff ... ff" does
+         * not work.
+         */
+        assert_true(memcmp("66:66:66:66:66:66", result, 17) == 0);
     }
 }
 
 void test_half_byte_to_char() 
 {
-    uint8_t half_byte = 9;
+    uint8_t half_byte = 0x9;
     char result = _half_byte_to_char(half_byte);
     assert_true(result == '9');
 
-    half_byte = 11;
+    half_byte = 0xB;
     result = _half_byte_to_char(half_byte);
-    assert_true(result == ('a' + 1));
+    assert_true(result == 'b');
 }
     
 void test_ccnl_is_local_addr_invalid() 


### PR DESCRIPTION
### Contribution description
The PR adds a length check on the ``len`` parameter of ``ll2ascii()``. If someone passes a ``len`` value of ``CCNL_LLADDR_STR_MAX_LEN  + 2`` to the function it basically overflows the ``out`` buffer (created inside the function). It also adds some documentation which clarifies why passing a string of "ffff...ff" to the ``ll2ascii`` function does not result in a string of "ff:ff:...ff"


### Issues/PRs references
See also PR #333 for the initial discussion on documentation in ``test_ll2ascii_valid()``