### PR TITLE
fixes potential memory leaks in file ccn-lite-rpc.c

### DIFF
--- a/src/ccnl-utils/src/ccn-lite-rpc.c
+++ b/src/ccnl-utils/src/ccn-lite-rpc.c
@@ -365,6 +365,9 @@ Usage:
 
         nonce = calloc(1, sizeof(*nonce));
         if (!nonce) {
+            if (expr) {
+                free(expr);
+            }
             return -1;
         }
         nonce->type = LRPC_NONCE;
@@ -375,6 +378,9 @@ Usage:
 
         req = calloc(1, sizeof(*req));
         if (!req) {
+            if (expr) {
+                free(expr);
+            }
             free(nonce);
             return -1;
         }
@@ -385,6 +391,10 @@ Usage:
 
     reqlen = sizeof(tmp);
     if (ccnl_switch_prependCoding(CCNL_ENC_LOCALRPC, &reqlen, tmp, &switchlen)) {
+        if (expr) {
+            free(expr);
+        }
+
         return -1;
     }
     memcpy(request, tmp+reqlen, switchlen);

--- a/src/ccnl-utils/src/ccn-lite-rpc.c
+++ b/src/ccnl-utils/src/ccn-lite-rpc.c
@@ -175,6 +175,7 @@ parsePrefixTerm(int lev, char **cpp)
                     free(term);
                 }
 
+                free(t2);
                 DEBUGMSG(ERROR, "parsePrefixTerm error: missing )\n");
                 return 0;
             }
@@ -365,9 +366,7 @@ Usage:
 
         nonce = calloc(1, sizeof(*nonce));
         if (!nonce) {
-            if (expr) {
-                free(expr);
-            }
+            free(expr);
             return -1;
         }
         nonce->type = LRPC_NONCE;
@@ -378,9 +377,7 @@ Usage:
 
         req = calloc(1, sizeof(*req));
         if (!req) {
-            if (expr) {
-                free(expr);
-            }
+            free(expr);
             free(nonce);
             return -1;
         }
@@ -391,9 +388,7 @@ Usage:
 
     reqlen = sizeof(tmp);
     if (ccnl_switch_prependCoding(CCNL_ENC_LOCALRPC, &reqlen, tmp, &switchlen)) {
-        if (expr) {
-            free(expr);
-        }
+        free(expr);
 
         return -1;
     }


### PR DESCRIPTION
### Contribution description
This PR addresses three potential memory leaks identified by the ``scan-build.sh`` script (which uses clang static analyzer). In order to avoid leaking memory a check is performed if memory has been previously allocated and if true it is freed accordingly.

### Issues/PRs references
Fixes #339 