### PR TITLE
fixes potential memory leak in ccn-lite-ctrl.c

### DIFF
--- a/src/ccnl-utils/src/ccn-lite-ctrl.c
+++ b/src/ccnl-utils/src/ccn-lite-ctrl.c
@@ -1605,6 +1605,7 @@ main(int argc, char *argv[])
     struct sockaddr_in si;
     int opt, i = 0, ret = -1;
     FILE *f = NULL;
+    char *udp_temp = NULL;
 
     while ((opt = getopt(argc, argv, "hk:mp:v:u:x:")) != -1) {
         switch (opt) {
@@ -1627,8 +1628,13 @@ main(int argc, char *argv[])
 #endif
             break;
         case 'u':
-            udp = strdup(optarg);
-            udp = strtok(udp, "/");
+            udp_temp = strdup(optarg);
+            /** strdup failed to allocate memory */
+            if (!udp_temp) {
+                return -1;
+            }
+
+            udp = strtok(udp_temp, "/");
             port = strtol(strtok(NULL, "/"), NULL, 0);
             use_udp = 1;
             printf("udp: <%s> <%i>\n", udp, port);


### PR DESCRIPTION
### Contribution description
The PR checks if a call to ``strdup`` failed and also introduces a new variable which stores the newly allocated memory before it is overwritten again by a call to ``strtok`` and thus, the memory allocated by ``strdup`` can't be freed anymore.


### Issues/PRs references
Fixes #327 