### PR TITLE
added missing free() of variable udp_temp in ccn-lite-ctrl.c

### DIFF
--- a/src/ccnl-utils/src/ccn-lite-ctrl.c
+++ b/src/ccnl-utils/src/ccn-lite-ctrl.c
@@ -1638,6 +1638,8 @@ main(int argc, char *argv[])
             port = strtol(strtok(NULL, "/"), NULL, 0);
             use_udp = 1;
             printf("udp: <%s> <%i>\n", udp, port);
+
+            free(udp_temp);
             break;
         case 'x':
             ux = optarg;


### PR DESCRIPTION
### Contribution description
This was previously part of PR #341  and got accidentally removed during the review process.


### Issues/PRs references
Related to #341 