### PR TITLE
fixes parameter of sizeof in {test_prefix,ccn-lite-rpc}.c

### DIFF
--- a/src/ccnl-utils/src/ccn-lite-rpc.c
+++ b/src/ccnl-utils/src/ccn-lite-rpc.c
@@ -370,7 +370,7 @@ Usage:
             return -1;
         }
         nonce->type = LRPC_NONCE;
-        nonce->aux = malloc(sizeof(int));
+        nonce->aux = malloc(sizeof(struct rdr_ds_s));
         memcpy(nonce->aux, &n, sizeof(int));
         nonce->u.binlen = sizeof(int);
         nonce->nextinseq = expr;

--- a/test/ccnl-core/test_prefix.c
+++ b/test/ccnl-core/test_prefix.c
@@ -11,7 +11,7 @@ void test_prefix_to_path()
     struct ccnl_prefix_s *p = ccnl_malloc(sizeof(struct ccnl_prefix_s));
     p->compcnt = 3;
     p->comp = (unsigned char**)ccnl_malloc(sizeof(unsigned char*) * p->compcnt);
-    p->complen = ccnl_malloc(sizeof(int) * p->compcnt);
+    p->complen = ccnl_malloc(sizeof(size_t) * p->compcnt);
     p->comp[0] = (unsigned char*)"path";
     p->complen[0] = 4;
     p->comp[1] = (unsigned char*)"to";


### PR DESCRIPTION
### Contribution description
The PR fixes the size of two calls to sizeof. During the last cleanup (see also #337) the size of some length parameter changed from ``int`` to ``size_t``. Hence, a call to sizeof needed to be changed from ``int`` to ``size_t`` in ``test_prefix.c``. The other parameter was changed from an ``int`` to ``struct rdr_ds_s`` in``ccn-lite-rpc.c``

### Issues/PRs references
Fixes #324 