### PR TITLE
ndntlv: remove superfluous write()

### DIFF
--- a/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
@@ -115,8 +115,6 @@ ccnl_ndntlv_bytes2pkt(uint64_t pkttype, uint8_t *start,
 #endif
 
 
-    write(1, *data, *datalen);
-
     DEBUGMSG(DEBUG, "ccnl_ndntlv_bytes2pkt len=%zu\n", *datalen);
 
     pkt = (struct ccnl_pkt_s*) ccnl_calloc(1, sizeof(struct ccnl_pkt_s));


### PR DESCRIPTION
### Contribution description

I wonder what this `write()` is supposed to do here. I couldn't find any custom `write()` definition in the code base, so it must be the systems `write()` function. This would mean, that the buffer is dumped to file handler 1 (stdout?). Is there a motive for doing so? To me, this looks more or less like a relict..

### Issues/PRs references

none
