### PR TITLE
CMake: make PACKETFORMATS configurable and properly define CCNL_RIOT

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,17 @@ set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 set(CMAKE_SYSTEM_NAME Generic)
 
 option(BUILD_TESTING "Build the testing tree." ON)
+option(CCNL_RIOT "Build for RIOT." OFF)
+option(CCNL_PACKETFORMAT_NDN "Use the NDN (v0.2) packet parser." ON)
+option(CCNL_PACKETFORMAT_CCNB "Use the CCNb packet parser." ON)
+option(CCNL_PACKETFORMAT_CCNTLV "Use the CCNTLV packet parser." ON)
+option(CCNL_PACKETFORMAT_LOCALRPC "Use localrpc." ON)
+
+if (CCNL_RIOT)
+   set(CCNL_PACKETFORMAT_CCNB OFF)
+   set(CCNL_PACKETFORMAT_CCNTLV OFF)
+   set(CCNL_PACKETFORMAT_LOCALRPC OFF)
+endif ()
 
 # CCNL flags
 set(CCNL_BASIC_FLAGS
@@ -25,7 +36,7 @@ set(CCNL_BASIC_FLAGS
 
 add_definitions(${CCNL_BASIC_FLAGS})
 
-if (NOT DEFINED CCNL_RIOT)
+if (NOT CCNL_RIOT)
    set(CCNL_EXTRA_FLAGS
         -DUSE_CCNxDIGEST
         -DUSE_MGMT
@@ -49,25 +60,24 @@ set(CCNL_PLATFORM_FLAGS
 add_definitions(${CCNL_PLATFORM_FLAGS})
 
 # Packet formats
-set(CCNL_PACKETFORMAT_FLAGS
-    -DUSE_SUITE_NDNTLV
-    CACHE PATH
-    "packet format flags for CCN-lite"
-)
-if (NOT DEFINED CCNL_RIOT)
-    set(CCNL_PACKETFORMAT_FLAGS
-        "${CCNL_PACKETFORMAT_FLAGS}"
-        -DUSE_SUITE_CCNB
-        -DUSE_SUITE_CCNTLV
-        -DUSE_SUITE_LOCALRPC
-        CACHE PATH
-        "packet format flags for CCN-lite"
-        FORCE
-    )
-endif()
+set(CCNL_PACKETFORMAT_FLAGS "")
+if (CCNL_PACKETFORMAT_NDN)
+   set(CCNL_PACKETFORMAT_FLAGS "${CCNL_PACKETFORMAT_FLAGS}" -DUSE_SUITE_NDNTLV)
+endif ()
+if (CCNL_PACKETFORMAT_CCNB)
+   set(CCNL_PACKETFORMAT_FLAGS "${CCNL_PACKETFORMAT_FLAGS}" -DUSE_SUITE_CCNB)
+endif ()
+if (CCNL_PACKETFORMAT_CCNTLV)
+   set(CCNL_PACKETFORMAT_FLAGS "${CCNL_PACKETFORMAT_FLAGS}" -DUSE_SUITE_CCNTLV)
+endif ()
+if (CCNL_PACKETFORMAT_LOCALRPC)
+   set(CCNL_PACKETFORMAT_FLAGS "${CCNL_PACKETFORMAT_FLAGS}" -DUSE_SUITE_LOCALRPC)
+endif ()
+set("${CCNL_PACKETFORMAT_FLAGS}" CACHE PATH "packet format flags for CCN-lite")
+
 add_definitions(${CCNL_PACKETFORMAT_FLAGS})
 
-if(DEFINED CCNL_RIOT)
+if(CCNL_RIOT)
     set(CCNL_RIOT_FLAGS
         -DCCNL_APP_RX
         -DUSE_DUP_CHECK
@@ -78,7 +88,7 @@ if(DEFINED CCNL_RIOT)
     add_definitions(${CCNL_RIOT_FLAGS})
 endif()
 
-if (NOT DEFINED CCNL_RIOT)
+if (NOT CCNL_RIOT)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra -Wall -Werror -std=c99 -g -pedantic") #TODO: add -fsanitize=address
 else()
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wextra -Wall -Werror -std=c99 -g")
@@ -86,7 +96,7 @@ endif()
 
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -g")
 
-if (NOT DEFINED CCNL_LINUXKERNEL AND NOT DEFINED CCNL_RIOT)
+if (NOT DEFINED CCNL_LINUXKERNEL AND NOT CCNL_RIOT)
     find_package(OpenSSL REQUIRED)
     include_directories(${OPENSSL_INCLUDE_DIR})
     message("OpenSSL include dir: ${OPENSSL_INCLUDE_DIR}")
@@ -94,20 +104,20 @@ if (NOT DEFINED CCNL_LINUXKERNEL AND NOT DEFINED CCNL_RIOT)
 endif()
 
 #add_subdirectory(ccnl-addons)
-#if (DEFINED CCNL_RIOT)
+#if (CCNL_RIOT)
   #  set(CMAKE_C_FLAGS ${RIOT_CFLAGS})
 #endif()
 if (NOT DEFINED CCNL_LINUXKERNEL)
     add_subdirectory(ccnl-core)
     add_subdirectory(ccnl-pkt)
     add_subdirectory(ccnl-fwd)
-    if (NOT DEFINED CCNL_RIOT)
+    if (NOT CCNL_RIOT)
         add_subdirectory(ccnl-unix)
         add_subdirectory(ccnl-relay)
         add_subdirectory(ccnl-utils)
     endif()
 endif()
-if (DEFINED CCNL_RIOT)
+if (CCNL_RIOT)
     add_subdirectory(ccnl-riot)
 endif()
 if (DEFINED CCNL_LINUXKERNEL)
@@ -116,7 +126,7 @@ endif()
 
 
 if (NOT DEFINED CCNL_LINUXKERNEL)
-if (NOT DEFINED CCNL_RIOT)
+if (NOT CCNL_RIOT)
     add_dependencies(ccn-lite-relay ccnl-core ccnl-pkt ccnl-fwd ccnl-unix)
 endif()
 endif()

--- a/src/ccnl-pkt/CMakeLists.txt
+++ b/src/ccnl-pkt/CMakeLists.txt
@@ -4,8 +4,30 @@ project(ccnl-pkt)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 
 include_directories(include ../ccnl-core/include ../ccnl-fwd/include)
- 
-file(GLOB SOURCES "src/*.c")
-file(GLOB HEADERS "include/*.h")
+
+set(SOURCES
+    "src/ccnl-pkt-builder.c"
+    "src/ccnl-pkt-switch.c"
+)
+set(HEADERS
+    "include/ccnl-pkt-builder.h"
+    "include/ccnl-pkt-switch.h"
+)
+if (CCNL_PACKETFORMAT_NDN)
+   set(SOURCES "${SOURCES}" "src/ccnl-pkt-ndntlv.c")
+   set(HEADERS "${HEADERS}" "include/ccnl-pkt-ndntlv.h")
+endif ()
+if (CCNL_PACKETFORMAT_CCNTLV)
+   set(SOURCES "${SOURCES}" "src/ccnl-pkt-ccntlv.c")
+   set(HEADERS "${HEADERS}" "include/ccnl-pkt-ccntlv.h")
+endif ()
+if (CCNL_PACKETFORMAT_CCNB)
+   set(SOURCES "${SOURCES}" "src/ccnl-pkt-ccnb.c")
+   set(HEADERS "${HEADERS}" "include/ccnl-pkt-ccnb.h")
+endif ()
+if (CCNL_PACKETFORMAT_LOCALRPC)
+   set(SOURCES "${SOURCES}" "src/ccnl-pkt-localrpc.c")
+   set(HEADERS "${HEADERS}" "include/ccnl-pkt-localrpc.h")
+endif ()
 
 add_library(${PROJECT_NAME} STATIC ${SOURCES} ${HEADERS})

--- a/src/ccnl-pkt/CMakeLists.txt
+++ b/src/ccnl-pkt/CMakeLists.txt
@@ -6,28 +6,20 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 include_directories(include ../ccnl-core/include ../ccnl-fwd/include)
 
 set(SOURCES
-    "src/ccnl-pkt-builder.c"
-    "src/ccnl-pkt-switch.c"
-)
-set(HEADERS
-    "include/ccnl-pkt-builder.h"
-    "include/ccnl-pkt-switch.h"
+  "src/ccnl-pkt-builder.c"
+  "src/ccnl-pkt-switch.c"
 )
 if (CCNL_PACKETFORMAT_NDN)
-   set(SOURCES "${SOURCES}" "src/ccnl-pkt-ndntlv.c")
-   set(HEADERS "${HEADERS}" "include/ccnl-pkt-ndntlv.h")
+  set(SOURCES "${SOURCES}" "src/ccnl-pkt-ndntlv.c")
 endif ()
 if (CCNL_PACKETFORMAT_CCNTLV)
-   set(SOURCES "${SOURCES}" "src/ccnl-pkt-ccntlv.c")
-   set(HEADERS "${HEADERS}" "include/ccnl-pkt-ccntlv.h")
+  set(SOURCES "${SOURCES}" "src/ccnl-pkt-ccntlv.c")
 endif ()
 if (CCNL_PACKETFORMAT_CCNB)
-   set(SOURCES "${SOURCES}" "src/ccnl-pkt-ccnb.c")
-   set(HEADERS "${HEADERS}" "include/ccnl-pkt-ccnb.h")
+  set(SOURCES "${SOURCES}" "src/ccnl-pkt-ccnb.c")
 endif ()
 if (CCNL_PACKETFORMAT_LOCALRPC)
-   set(SOURCES "${SOURCES}" "src/ccnl-pkt-localrpc.c")
-   set(HEADERS "${HEADERS}" "include/ccnl-pkt-localrpc.h")
+  set(SOURCES "${SOURCES}" "src/ccnl-pkt-localrpc.c")
 endif ()
 
-add_library(${PROJECT_NAME} STATIC ${SOURCES} ${HEADERS})
+add_library(${PROJECT_NAME} STATIC ${SOURCES})


### PR DESCRIPTION
### Contribution description
This contribution includes two changes
1. it properly defines `CCNL_RIOT` as a `cmake` option. Without this change, `cmake` complains about `CCNL_RIOT` not being set/ignored by `cmake`. I set the default value to `OFF` for `CCNL_RIOT`. It can be turned on with `-DCCNL_RIOT=ON` when `cmake` is invoked.
2. Existing packet formats are not easily configurable from the command line with the current solution. The proposed change defines options for each packet format.

You can look at the output of `cmake -DCCNL_RIOT=OFF .. && make` and `cmake -DCCNL_RIOT=ON .. && make` to see how the build system chooses the correct packet format.

### Issues/PRs references
none