### PR TITLE
interest: fix timeout calculation for suite != NDN-TLV

### DIFF
--- a/src/ccnl-core/include/ccnl-pkt-util.h
+++ b/src/ccnl-core/include/ccnl-pkt-util.h
@@ -25,6 +25,8 @@
 #include <stdint.h>
 #include <stddef.h>
 
+#include "ccnl-pkt.h"
+
 uint8_t
 ccnl_isSuite(int suite);
 
@@ -51,5 +53,15 @@ ccnl_pkt2suite(uint8_t *data, size_t len, size_t *skip);
  */
 int
 ccnl_cmp2int(unsigned char *cmp, size_t cmplen);
+
+/**
+ * Returns the Interest lifetime in seconds
+ *
+ * @param[in] pkt Pointer to the Interest packet
+ *
+ * @return        The interest lifetime in seconds
+ */
+uint64_t
+ccnl_pkt_interest_lifetime(const struct ccnl_pkt_s *pkt);
 
 #endif

--- a/src/ccnl-core/src/ccnl-interest.c
+++ b/src/ccnl-core/src/ccnl-interest.c
@@ -61,7 +61,8 @@ ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
         return NULL;
     i->pkt = *pkt;
     /* currently, the aging function relies on seconds rather than on milli seconds */
-    i->lifetime = (*pkt)->s.ndntlv.interestlifetime / 1000;
+    i->lifetime = ccnl_pkt_interest_lifetime(*pkt);
+
     *pkt = NULL;
     i->from = from;
     i->last_used = CCNL_NOW();

--- a/src/ccnl-core/src/ccnl-pkt-util.c
+++ b/src/ccnl-core/src/ccnl-pkt-util.c
@@ -220,3 +220,23 @@ ccnl_cmp2int(unsigned char *cmp, size_t cmplen)
 
     return 0;
 }
+
+uint64_t
+ccnl_pkt_interest_lifetime(const struct ccnl_pkt_s *pkt)
+{
+    switch(pkt->suite) {
+#ifdef USE_SUITE_CCNTLV
+    case CCNL_SUITE_CCNTLV:
+        /* CCN-TLV parser does not support lifetime parsing, yet. */
+        return CCNL_INTEREST_TIMEOUT;
+#endif
+#ifdef USE_SUITE_NDNTLV
+    case CCNL_SUITE_NDNTLV:
+        return (pkt->s.ndntlv.interestlifetime / 1000);
+#endif
+    default:
+        break;
+    }
+
+    return CCNL_INTEREST_TIMEOUT;
+}


### PR DESCRIPTION
### Contribution description
Currently, the lifetime for new interests is read from `pkt->s.ndntlv.interestlifetime` even for packets that have an CCNx encoding. Since `s.ndntlv` is a union in this case, it contains *something*, but definitely not the correct interest lifetime for CCNx. On the other hand, the CCNx parser does not really parse the interest lifetime hop-by-hop option. This patch adds an abstraction to figure out the suite and return the correct lifetime (`s.ndntlv.interestlifetime` for NDN and `CCNL_INTEREST_LIFETIME` for CCNx and others).

### Issues/PRs references
Probably related to #210 