### PR TITLE
ccnl-pkt-util: header cleanup

### DIFF
--- a/src/ccnl-core/src/ccnl-pkt-util.c
+++ b/src/ccnl-core/src/ccnl-pkt-util.c
@@ -19,7 +19,6 @@
  * 2017-06-20 created
  */
 
-#ifndef CCNL_LINUXKERNEL
 #include "ccnl-pkt-util.h"
 #include "ccnl-defs.h"
 #include "ccnl-os-time.h"
@@ -28,17 +27,6 @@
 #include "ccnl-pkt-ndntlv.h"
 #include "ccnl-pkt-switch.h"
 #include "ccnl-logging.h"
-#else
-#include <ccnl-pkt-util.h>
-#include <ccnl-defs.h>
-#include <ccnl-os-time.h>
-#include <ccnl-pkt-ccnb.h>
-#include <ccnl-pkt-ccntlv.h>
-#include <ccnl-pkt-ndntlv.h>
-#include <ccnl-pkt-switch.h>
-#include <ccnl-logging.h>
-#endif
-
 
 int
 ccnl_str2suite(char *cp)


### PR DESCRIPTION
### Contribution description
This is just a cleanup ..
The header include list seems to be duplicated for the **linux kernel** build configuration. I don't know what the initial intention was, but merely the header include style differes (`""` vs `<>`). Nevertheless, I doubt that this really has an effect and thus IMO we can deduplicate this include list.


### Issues/PRs references
none