### PR TITLE
ccnl-relay: remove printf during forwarding

### DIFF
--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -391,7 +391,6 @@ ccnl_interest_propagate(struct ccnl_relay_s *ccnl, struct ccnl_interest_s *i)
     // CCNL strategy: we forward on all FWD entries with a prefix match
 
     for (fwd = ccnl->fib; fwd; fwd = fwd->next) {
-        printf("fwd: %p\n", (void*)fwd);
         if (!fwd->prefix) {
             continue;
         }


### PR DESCRIPTION
### Contribution description
A `printf` was introduced in https://github.com/cn-uofbasel/ccn-lite/commit/d6007f23bdf3bbd418dbbb8b3ceb1792ea0b3ff7. This PR removes that again.

### Issues/PRs references