### PR TITLE
type fixes for cross-compiling (e.g. with RIOT)

### DIFF
--- a/src/ccnl-core/include/ccnl-prefix.h
+++ b/src/ccnl-core/include/ccnl-prefix.h
@@ -93,7 +93,7 @@ ccnl_prefix_appendCmp(struct ccnl_prefix_s *prefix, uint8_t *cmp, size_t cmplen)
  * @return      0 on success else < 0
 */
 int
-ccnl_prefix_addChunkNum(struct ccnl_prefix_s *prefix, unsigned int chunknum);
+ccnl_prefix_addChunkNum(struct ccnl_prefix_s *prefix, uint32_t chunknum);
 
 /**
  * @brief Compares two Prefix datastructures
@@ -107,7 +107,7 @@ ccnl_prefix_addChunkNum(struct ccnl_prefix_s *prefix, unsigned int chunknum);
  * @return      0 if full match (CMP_EXACT)
  * @return      n>0 for matched components (mode = CMP_MATCH, CMP_LONGEST)
 */
-int
+int32_t
 ccnl_prefix_cmp(struct ccnl_prefix_s *pfx, unsigned char *md,
                 struct ccnl_prefix_s *nam, int mode);
 
@@ -153,7 +153,7 @@ unescape_component(char *comp);
  * @return The prefix datastruct that was created
 */
 struct ccnl_prefix_s *
-ccnl_URItoPrefix(char* uri, int suite, unsigned int *chunknum);
+ccnl_URItoPrefix(char* uri, int suite, uint32_t *chunknum);
 
 /**
  * @brief Transforms a URI to a list of strings 

--- a/src/ccnl-core/src/ccnl-content.c
+++ b/src/ccnl-core/src/ccnl-content.c
@@ -50,9 +50,9 @@ ccnl_content_new(struct ccnl_pkt_s **pkt)
     char s[CCNL_MAX_PREFIX_SIZE];
     (void) s;
 
-    DEBUGMSG_CORE(TRACE, "ccnl_content_new %p <%s [%d]>\n",
+    DEBUGMSG_CORE(TRACE, "ccnl_content_new %p <%s [%lu]>\n",
              (void*) *pkt, ccnl_prefix_to_str((*pkt)->pfx, s, CCNL_MAX_PREFIX_SIZE),
-             ((*pkt)->pfx->chunknum) ? *((*pkt)->pfx->chunknum) : 0);
+             ((*pkt)->pfx->chunknum) ? (long unsigned) *((*pkt)->pfx->chunknum) : (long unsigned) 0);
 
     c = (struct ccnl_content_s *) ccnl_calloc(1, sizeof(struct ccnl_content_s));
     if (!c)

--- a/src/ccnl-core/src/ccnl-dump.c
+++ b/src/ccnl-core/src/ccnl-dump.c
@@ -83,8 +83,8 @@ ccnl_dump(int lev, int typ, void *p)
             break;
         case CCNL_PREFIX:
             INDENT(lev);
-            CONSOLE("%p PREFIX len=%d val=%s\n",
-                    (void *) pre, pre->compcnt, ccnl_prefix_to_str(pre,s,CCNL_MAX_PREFIX_SIZE));
+            CONSOLE("%p PREFIX len=%lu val=%s\n",
+                    (void *) pre, (long unsigned) pre->compcnt, ccnl_prefix_to_str(pre,s,CCNL_MAX_PREFIX_SIZE));
             break;
         case CCNL_RELAY:
             INDENT(lev);

--- a/src/ccnl-core/src/ccnl-prefix.c
+++ b/src/ccnl-core/src/ccnl-prefix.c
@@ -176,7 +176,7 @@ ccnl_prefix_addChunkNum(struct ccnl_prefix_s *prefix, uint32_t chunknum)
 {
     if (chunknum >= 0xff) {
       DEBUGMSG_CUTL(WARNING, "addChunkNum is only implemented for "
-               "chunknum smaller than 0xff (%d)\n", chunknum);
+               "chunknum smaller than 0xff (%lu)\n", (long unsigned) chunknum);
         return -1;
     }
 
@@ -422,15 +422,15 @@ ccnl_prefix_cmp(struct ccnl_prefix_s *pfx, unsigned char *md,
         clen = i < pfx->compcnt ? pfx->complen[i] : 32; // SHA256_DIGEST_LEN
         if (clen != nam->complen[i] || memcmp(comp, nam->comp[i], nam->complen[i])) {
             rc = mode == CMP_EXACT ? -1 : (int32_t) i;
-            DEBUGMSG(VERBOSE, "component mismatch: %i\n", i);
+            DEBUGMSG(VERBOSE, "component mismatch: %lu\n", (long unsigned) i);
             goto done;
         }
     }
     // FIXME: we must also inspect chunknum here!
     rc = (mode == CMP_EXACT) ? 0 : (int32_t) i;
 done:
-    DEBUGMSG(TRACE, "  cmp result: pfxlen=%d cmplen=%d namlen=%d matchlen=%d\n",
-             pfx->compcnt, plen, nam->compcnt, rc);
+    DEBUGMSG(TRACE, "  cmp result: pfxlen=%lu cmplen=%lu namlen=%lu matchlen=%ld\n",
+             (long unsigned) pfx->compcnt, (long unsigned) plen, (long unsigned) nam->compcnt, (long) rc);
     return rc;
 }
 
@@ -648,7 +648,7 @@ ccnl_prefix_debug_info(struct ccnl_prefix_s *p) {
     }
     len += result;
 
-    result = snprintf(buf + len, CCNL_MAX_PACKET_SIZE - len, "compcnt:%i ", p->compcnt);
+    result = snprintf(buf + len, CCNL_MAX_PACKET_SIZE - len, "compcnt:%lu ", (long unsigned) p->compcnt);
     if (!(result > -1 && (unsigned) result < (CCNL_MAX_PACKET_SIZE - len))) {
         DEBUGMSG(ERROR, "Could not print prefix, since out of allocated memory");
         ccnl_free(buf);
@@ -697,7 +697,7 @@ ccnl_prefix_debug_info(struct ccnl_prefix_s *p) {
     }
     len += result;
     for (i = 0; i < p->compcnt; i++) {
-        result = snprintf(buf + len, CCNL_MAX_PACKET_SIZE - len, "%.*s", (uint32_t) p->complen[i], p->comp[i]);
+        result = snprintf(buf + len, CCNL_MAX_PACKET_SIZE - len, "%.*s", (int) p->complen[i], p->comp[i]);
         if (!(result > -1 && (unsigned) result < (CCNL_MAX_PACKET_SIZE - len))) {
             DEBUGMSG(ERROR, "Could not print prefix, since out of allocated memory");
             ccnl_free(buf);

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -404,8 +404,8 @@ ccnl_interest_propagate(struct ccnl_relay_s *ccnl, struct ccnl_interest_s *i)
 
         rc = ccnl_prefix_cmp(fwd->prefix, NULL, i->pkt->pfx, CMP_LONGEST);
 
-        DEBUGMSG_CORE(DEBUG, "  ccnl_interest_propagate, rc=%d/%d\n",
-                 rc, fwd->prefix->compcnt);
+        DEBUGMSG_CORE(DEBUG, "  ccnl_interest_propagate, rc=%ld/%ld\n",
+                 (long) rc, (long) fwd->prefix->compcnt);
         if (rc < (signed) fwd->prefix->compcnt) {
             continue;
         }
@@ -953,7 +953,7 @@ ccnl_cs_dump(struct ccnl_relay_s *ccnl)
         printf("CS[%u]: %s [%d]: %.*s\n", i++,
                ccnl_prefix_to_str(c->pkt->pfx,s,CCNL_MAX_PREFIX_SIZE),
                (c->pkt->pfx->chunknum)? (signed) *(c->pkt->pfx->chunknum) : -1,
-               (int32_t) c->pkt->contlen, c->pkt->content);
+               (int) c->pkt->contlen, c->pkt->content);
         c = c->next;
     }
 #endif

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -159,7 +159,7 @@ ccnl_open_netif(kernel_pid_t if_pid, gnrc_nettype_t netreg_type)
         return -ECANCELED;
     }
     i->mtu = (int)mtu;
-    DEBUGMSG(DEBUG, "interface's MTU is set to %i\n", i->mtu);
+    DEBUGMSG(DEBUG, "interface's MTU is set to %lu\n", (unsigned long) i->mtu);
 
     res = gnrc_netapi_get(if_pid, NETOPT_ADDR_LEN, 0, &(i->addr_len), sizeof(i->addr_len));
     if (res < 0) {
@@ -545,7 +545,7 @@ ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, int buf_len
         return -1;
     }
 
-    DEBUGMSG(INFO, "interest for chunk number: %u\n", (prefix->chunknum == NULL) ? 0 : *prefix->chunknum);
+    DEBUGMSG(INFO, "interest for chunk number: %lu\n", (prefix->chunknum == NULL) ? (unsigned long) 0 : (unsigned long) *prefix->chunknum);
 
     if (!prefix) {
         DEBUGMSG(ERROR, "prefix could not be created!\n");


### PR DESCRIPTION
### Contribution description
There are a lot of type issues when cross-compiling (e.g. for ARM Cortex with RIOT), such that the compiling fails. This PR addresses those issues.