### PR TITLE
ccnl-interest: check for max pit entries and free if full

### DIFF
--- a/src/ccnl-core/src/ccnl-interest.c
+++ b/src/ccnl-core/src/ccnl-interest.c
@@ -66,7 +66,16 @@ ccnl_interest_new(struct ccnl_relay_s *ccnl, struct ccnl_face_s *from,
     *pkt = NULL;
     i->from = from;
     i->last_used = CCNL_NOW();
+
+    if (ccnl->pitcnt >= ccnl->max_pit_entries) {
+        ccnl_pkt_free(i->pkt);
+        ccnl_free(i);
+        return NULL;
+    }
+
     DBL_LINKED_LIST_ADD(ccnl->pit, i);
+
+    ccnl->pitcnt++;
 
 #ifdef CCNL_RIOT
     ccnl_evtimer_reset_interest_retrans(i);

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -358,6 +358,9 @@ ccnl_interest_remove(struct ccnl_relay_s *ccnl, struct ccnl_interest_s *i)
         i->pending = tmp;
     }
     i2 = i->next;
+
+    ccnl->pitcnt--;
+
     DBL_LINKED_LIST_REMOVE(ccnl->pit, i);
 
     if (i->pkt) {


### PR DESCRIPTION
### Contribution description
Currently, CCN-lite does not 1) track the number of active PIT entries, and 2) does not check for the limit of maximum PIT entries.

This PR adapts the `ccnl_interest_new()` function.