### PR TITLE
ccnl-riot: add a RIOT cleanup functions for Interest structures

### DIFF
--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -348,8 +348,7 @@ ccnl_interest_remove(struct ccnl_relay_s *ccnl, struct ccnl_interest_s *i)
     DEBUGMSG_CORE(TRACE, "ccnl_interest_remove %p\n", (void *) i);
 
 #ifdef CCNL_RIOT
-    evtimer_del((evtimer_t *)(&ccnl_evtimer), (evtimer_event_t *)&i->evtmsg_retrans);
-    evtimer_del((evtimer_t *)(&ccnl_evtimer), (evtimer_event_t *)&i->evtmsg_timeout);
+    ccnl_riot_interest_remove((evtimer_t *)(&ccnl_evtimer), i);
 #endif
 
     while (i->pending) {

--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -332,6 +332,18 @@ static inline void ccnl_evtimer_set_cs_timeout(struct ccnl_content_s *c)
     evtimer_add_msg(&ccnl_evtimer, &c->evtmsg_cstimeout, ccnl_event_loop_pid);
 }
 
+/**
+ * @brief Remove RIOT related structures for Interests
+ *
+ * @param[in] et        RIOT related event queue that holds timer events
+ * @param[in] i         The Interest structure
+ */
+static inline void ccnl_riot_interest_remove(evtimer_t *et, struct ccnl_interest_s *i)
+{
+    evtimer_del(et, (evtimer_event_t *)&i->evtmsg_retrans);
+    evtimer_del(et, (evtimer_event_t *)&i->evtmsg_timeout);
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description
This PR moves RIOT related Interest cleanups into a function, such that further modifications of the cleanup are simpler in the future.