### PR TITLE
ccn-lite-riot: remove message from queue on remove interest

### DIFF
--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -342,6 +342,17 @@ static inline void ccnl_riot_interest_remove(evtimer_t *et, struct ccnl_interest
 {
     evtimer_del(et, (evtimer_event_t *)&i->evtmsg_retrans);
     evtimer_del(et, (evtimer_event_t *)&i->evtmsg_timeout);
+
+    unsigned state = irq_disable();
+    /* remove messages that relate to this interest from the message queue */
+    thread_t *me = (thread_t*) sched_threads[sched_active_pid];
+    for (unsigned j = 0; j <= me->msg_queue.mask; j++) {
+        if (me->msg_array[j].content.ptr == i) {
+            /* removing is done by setting to zero */
+            memset(&(me->msg_array[j]), 0, sizeof(me->msg_array[j]));
+        }
+    }
+    irq_restore(state);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

This PR removes any message that relates to an Interest from the RIOT message queue of the the CCN-lite thread, when removing this Interest (i.e., by  `ccnl_interest_remove()`). This fixes a rare case that occurs when a retransmission message is queued and can't be processed before the pending Interest is satisfied, which will call  `ccnl_interest_remove()`. Without this fix, the message will be processed at some point and reference an Interest that doesn't exist anymore.