### PR TITLE
ccn-lite-riot: add include for irq.h

### DIFF
--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -32,6 +32,7 @@
 #include "ccnl-dispatch.h"
 //#include "ccnl-pkt-builder.h"
 
+#include "irq.h"
 #include "evtimer.h"
 #include "evtimer_msg.h"
 


### PR DESCRIPTION
### Contribution description

This PR adds the include for `irq.h` to the RIOT adapter which is needed to run in RIOT native.


### Issues/PRs references

#359
