### PR TITLE
ccnl-relay: cast 't' to uint32_t

### DIFF
--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -760,7 +760,7 @@ ccnl_do_ageing(void *ptr, void *dummy)
     }
     while (f) {
         if (!(f->flags & CCNL_FACE_FLAGS_STATIC) &&
-                (f->last_used + CCNL_FACE_TIMEOUT) <= t){
+                (f->last_used + CCNL_FACE_TIMEOUT) <= (uint32_t) t){
             DEBUGMSG_CORE(TRACE, "AGING: FACE REMOVE %p\n", (void*) f);
             f = ccnl_face_remove(relay, f);
         } else {


### PR DESCRIPTION
### Contribution description
RIOT `native` is not happy with the definition of `time_t`(long int) vs `uint32_t` (unsigned). Since `t` can actually be never of negative time, the cast to `uint32_t` is safe.

### Issues/PRs references
--