### PR TITLE
Revert "ccnl-prefix: correct documentation"

### DIFF
--- a/src/ccnl-core/include/ccnl-prefix.h
+++ b/src/ccnl-core/include/ccnl-prefix.h
@@ -116,11 +116,14 @@ ccnl_prefix_cmp(struct ccnl_prefix_s *pfx, unsigned char *md,
  *
  * @param[in] prefix        Prefix to be compared (shorter of Longest Prefix matching)
  * @param[in] minsuffix     ?
- * @param[in] maxsuffix     ?
+ * @param[in] maxsuffix     ? 
  * @param[in] c             Content to test the prefix against
  *
- * @return      0 if no match
- * @return      1 if full match
+ * @return      -1 if no match at all (all modes) or exact match failed
+ * @return      -2 mismatch in expected number of components between prefix and content
+ * @return      -3 computation of digest failed 
+ * @return      0 if full match
+ * @return      n>0 for matched components
 */
 int8_t
 ccnl_i_prefixof_c(struct ccnl_prefix_s *prefix,


### PR DESCRIPTION
I really don't know what lead to the confusion back then, but obviously `ccnl_i_prefixof_c` **can** return other values, so I'm reverting the commit.

See [here](https://github.com/cn-uofbasel/ccn-lite/blob/master/src/ccnl-core/src/ccnl-prefix.c#L387), [here](https://github.com/cn-uofbasel/ccn-lite/blob/master/src/ccnl-core/src/ccnl-prefix.c#L459), and [here](https://github.com/cn-uofbasel/ccn-lite/blob/master/src/ccnl-core/src/ccnl-prefix.c#L470).