### PR TITLE
ccnl_i_prefixof_c: fix and use CMP_EXACT

### DIFF
--- a/src/ccnl-core/src/ccnl-prefix.c
+++ b/src/ccnl-core/src/ccnl-prefix.c
@@ -471,8 +471,9 @@ ccnl_i_prefixof_c(struct ccnl_prefix_s *prefix,
         }
     }
 
-    int32_t cmp = ccnl_prefix_cmp(p, md, prefix, CMP_MATCH);
-    return cmp > 0 && (uint32_t) cmp == prefix->compcnt;
+    int32_t cmp = ccnl_prefix_cmp(p, md, prefix, CMP_EXACT);
+    return cmp;
+
 }
 
 #endif // NEEDS_PREFIX_MATCHING

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -610,8 +610,8 @@ ccnl_content_serve_pending(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
         switch (i->pkt->pfx->suite) {
 #ifdef USE_SUITE_CCNB
         case CCNL_SUITE_CCNB:
-            if (!ccnl_i_prefixof_c(i->pkt->pfx, i->pkt->s.ccnb.minsuffix,
-                       i->pkt->s.ccnb.maxsuffix, c)) {
+            if (ccnl_i_prefixof_c(i->pkt->pfx, i->pkt->s.ccnb.minsuffix,
+                       i->pkt->s.ccnb.maxsuffix, c) < 0) {
                 // XX must also check i->ppkd
                 i = i->next;
                 continue;
@@ -629,8 +629,8 @@ ccnl_content_serve_pending(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
 #endif
 #ifdef USE_SUITE_NDNTLV
         case CCNL_SUITE_NDNTLV:
-            if (!ccnl_i_prefixof_c(i->pkt->pfx, i->pkt->s.ndntlv.minsuffix,
-                       i->pkt->s.ndntlv.maxsuffix, c)) {
+            if (ccnl_i_prefixof_c(i->pkt->pfx, i->pkt->s.ndntlv.minsuffix,
+                    i->pkt->s.ndntlv.maxsuffix, c) < 0) {
                 // XX must also check i->ppkl,
                 i = i->next;
                 continue;

--- a/src/ccnl-pkt/src/ccnl-pkt-ccnb.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ccnb.c
@@ -360,7 +360,7 @@ ccnl_ccnb_cMatch(struct ccnl_pkt_s *p, struct ccnl_content_s *c)
     assert(p->suite == CCNL_SUITE_CCNB);
 #endif
 
-    if (!ccnl_i_prefixof_c(p->pfx, p->s.ccnb.minsuffix, p->s.ccnb.maxsuffix, c)) {
+    if (ccnl_i_prefixof_c(p->pfx, p->s.ccnb.minsuffix, p->s.ccnb.maxsuffix, c) < 0) {
         return -1;
     }
     if (p->s.ccnb.ppkd && !buf_equal(p->s.ccnb.ppkd, c->pkt->s.ccnb.ppkd)) {

--- a/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
@@ -347,7 +347,7 @@ ccnl_ndntlv_cMatch(struct ccnl_pkt_s *p, struct ccnl_content_s *c)
     assert(p->suite == CCNL_SUITE_NDNTLV);
 #endif
 
-    if (!ccnl_i_prefixof_c(p->pfx, p->s.ndntlv.minsuffix, p->s.ndntlv.maxsuffix, c)) {
+    if (ccnl_i_prefixof_c(p->pfx, p->s.ndntlv.minsuffix, p->s.ndntlv.maxsuffix, c) < 0) {
         return -1;
     }
 


### PR DESCRIPTION
### Contribution description

[`cmp > 0 && (uint32_t) cmp == prefix->compcnt;`](https://github.com/cn-uofbasel/ccn-lite/blob/master/src/ccnl-core/src/ccnl-prefix.c#L475) seems like the aim to do an exact match. This PR changes to simply use `CMP_EXACT`.

`ccnl_i_prefixof_c` can return different negative values which indicate error cases. Users of this function (see [here](https://github.com/cn-uofbasel/ccn-lite/blob/master/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c#L350) for example) should not only fail if `!ccnl_i_prefixof_c` but rather when values are negative.

Please review with care! I'm not 100% sure I missed something.

### Testing
- This can be tested with RIOT. Check out this branch locally and in your RIOT clone, point to your local ccn-lite repoby setting the build variable  in the [pkg Makefile](https://github.com/PeterKietzmann/RIOT/blob/master/pkg/ccn-lite/Makefile) like: 
`PKG_SOURCE_LOCAL ?= $(RIOTBASE)/../ccn-lite`.
- Build the ccn-lite demo application under *RIOT/examples/ccn-lite-relay* for `native`.
- Start two native instances with `make term` and `make term PORT=tap1`.
- On one instance, add two contents:
`ccnl_cs /foo "Bar!"`
`ccnl_cs /a/b/c/d content123`
- On the other instance, send an interest requests for both items:
`ccnl_int /foo`
`ccnl_int /a/b/c/d`

#### w/o this PR (on current ccn-lite master)
```
main(): This is RIOT! (Version: 2020.01-devel-25-gcbee3-HEAD)
Basic CCN-Lite example
> ccnl_int /foo
ccnl_int /foo
> PKTDUMP: data received:
~~ SNIP  0 - size:   4 byte, type: GNRC_NETTYPE_CCN_CHUNK (2)
Content is: Bar!
~~ PKT    -  1 snips, total size:   4 byte
ccnl_int /a/b/c/d
ccnl_int /a/b/c/d
PKTDUMP: data received:
~~ SNIP  0 - size:   4 byte, type: GNRC_NETTYPE_CCN_CHUNK (2)
Content is: Bar!
~~ PKT    -  1 snips, total size:   4 byte
```
-> Second request is answered incorrectly from local CS

### w/ this PR
See the requested content being received
```
main(): This is RIOT! (Version: 2020.01-devel-25-gcbee3-HEAD)
Basic CCN-Lite example
> ccnl_int /foo
ccnl_int /foo
>PKTDUMP: data received:
~~ SNIP  0 - size:   4 byte, type: GNRC_NETTYPE_CCN_CHUNK (2)
Content is: Bar!
~~ PKT    -  1 snips, total size:   4 byte
 ccnl_int /a/b/c/d
ccnl_int /a/b/c/d
> PKTDUMP: data received:
~~ SNIP  0 - size:  10 byte, type: GNRC_NETTYPE_CCN_CHUNK (2)
Content is: content123
~~ PKT    -  1 snips, total size:  10 byte
```

-> Both requests answered correctly.
