### PR TITLE
ccnl_prefix_cmp: precise documentation

### DIFF
--- a/src/ccnl-core/include/ccnl-prefix.h
+++ b/src/ccnl-core/include/ccnl-prefix.h
@@ -104,7 +104,7 @@ ccnl_prefix_addChunkNum(struct ccnl_prefix_s *prefix, uint32_t chunknum);
  * @param[in] mode  Mode for prefix comp (CMP_EXACT, CMP_MATCH, CMP_LONGEST)
  *
  * @return      -1 if no match at all (all modes) or exact match failed
- * @return      0 if full match (CMP_EXACT)
+ * @return      0 if full match (mode = CMP_EXACT) or no components match (mode = CMP_MATCH)
  * @return      n>0 for matched components (mode = CMP_MATCH, CMP_LONGEST)
 */
 int32_t

--- a/src/ccnl-core/src/ccnl-prefix.c
+++ b/src/ccnl-core/src/ccnl-prefix.c
@@ -385,8 +385,8 @@ int32_t
 ccnl_prefix_cmp(struct ccnl_prefix_s *pfx, unsigned char *md,
                 struct ccnl_prefix_s *nam, int mode)
 /* returns -1 if no match at all (all modes) or exact match failed
-   returns  0 if full match (CMP_EXACT)
-   returns n>0 for matched components (CMP_MATCH, CMP_LONGEST) */
+   returns  0 if full match (mode = CMP_EXACT) or no components match (mode = CMP_MATCH)
+   returns n>0 for matched components (mode = CMP_MATCH, CMP_LONGEST) */
 {
     int32_t rc = -1;
     size_t clen;


### PR DESCRIPTION
### Contribution description

If `ccnl_prefix_cmp` is called with `CMP_MATCH`, a return value of 0 zero indicates that **no** components match (see [here](https://github.com/cn-uofbasel/ccn-lite/blob/master/src/ccnl-core/src/ccnl-prefix.c#L424)). This PR fixes the documentation.