### PR TITLE
src/ccn-lite-riot: remove access to xtimer_t members in static init

### DIFF
--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -474,7 +474,7 @@ ccnl_start(void)
     return ccnl_event_loop_pid;
 }
 
-static xtimer_t _wait_timer = { .target = 0, .long_target = 0 };
+static xtimer_t _wait_timer;
 static msg_t _timeout_msg;
 int
 ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout)


### PR DESCRIPTION
<!--
Before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the CCN-lite
coding conventions, see https://github.com/cn-uofbasel/ccn-lite/wiki/Coding-conventions.
-->

### Contribution description

This removes an unnecessary access to `xtimer_t` members for the static init of the _wait_timer variable.
This avoids a compilation problem if the struct definition is be changed in RIOT upstream.

<!--
Put here the description of your contribution:
- describe which part(s) of CCN-lite is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
https://github.com/RIOT-OS/RIOT/pull/9530
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
