### PR TITLE
Enable custom caching decision and cache replacement strategies

### DIFF
--- a/src/ccn-lite-simu.c
+++ b/src/ccn-lite-simu.c
@@ -53,6 +53,7 @@
 
 #define local_producer(...) 0
 #define cache_strategy_remove(...)      0
+#define cache_strategy_cache(...)       0
 
 #include "ccnl-ext-debug.c"
 #include "ccnl-os-time.c"

--- a/src/ccnl-android/native/src/ccn-lite-android.c
+++ b/src/ccnl-android/native/src/ccn-lite-android.c
@@ -53,6 +53,7 @@ unsigned char keyid[32];
 
 #define ccnl_app_RX(x,y)                do{}while(0)
 #define cache_strategy_remove(...)      0
+#define cache_strategy_cache(...)       0
 
 
 

--- a/src/ccnl-core/include/ccnl-relay.h
+++ b/src/ccnl-core/include/ccnl-relay.h
@@ -66,6 +66,12 @@ struct ccnl_relay_s {
 };
 
 /**
+ * @brief Function pointer type for caching strategy function
+ */
+typedef int (*ccnl_cache_strategy_func)(struct ccnl_relay_s *relay,
+                                        struct ccnl_content_s *c);
+
+/**
  * @brief Broadcast an interest message to all available interfaces
  *
  * @param[in] ccnl          The CCN-lite relay used to send the interest
@@ -281,5 +287,24 @@ ccnl_cs_remove(struct ccnl_relay_s *ccnl, char *prefix);
 struct ccnl_content_s *
 ccnl_cs_lookup(struct ccnl_relay_s *ccnl, char *prefix);
 
+/**
+ * @brief Set a function to control the cache replacement strategy
+ *
+ * The given function will be called if the cache is full and a new content
+ * chunk arrives. It shall remove (at least) one entry from the cache.
+ *
+ * If the return value of @p func is 0, the default caching strategy will be
+ * applied by the CCN-lite stack. If the return value is 1, it is assumed that
+ * (at least) one entry has been removed from the cache.
+ *
+ * @param[in] func  The function to be called for an incoming content chunk if
+ *                  the cache is full.
+ */
+void ccnl_set_cache_strategy_remove(ccnl_cache_strategy_func func);
+
+/**
+ * @brief May be defined for a particular caching strategy
+ */
+int cache_strategy_remove(struct ccnl_relay_s *relay, struct ccnl_content_s *c);
 #endif //CCNL_RELAY_H
 /** @} */

--- a/src/ccnl-core/include/ccnl-relay.h
+++ b/src/ccnl-core/include/ccnl-relay.h
@@ -303,8 +303,29 @@ ccnl_cs_lookup(struct ccnl_relay_s *ccnl, char *prefix);
 void ccnl_set_cache_strategy_remove(ccnl_cache_strategy_func func);
 
 /**
+ * @brief Set a function to control the caching decision strategy
+ *
+ * The given function will be called when a new content chunk arrives.
+ * It decides whether or not to cache the new content.
+ *
+ * If the return value of @p func is 1, the content chunk will be cached;
+ * otherwise, it will be discarded. If no caching decision strategy is
+ * implemented, all content chunks will be cached.
+ *
+ * @param[in] func  The function to be called for an incoming content
+ *                  chunk.
+ */
+void ccnl_set_cache_strategy_cache(ccnl_cache_strategy_func func);
+
+/**
  * @brief May be defined for a particular caching strategy
  */
 int cache_strategy_remove(struct ccnl_relay_s *relay, struct ccnl_content_s *c);
+
+/**
+ * @brief May be defined for a particular caching decision strategy
+ */
+int cache_strategy_cache(struct ccnl_relay_s *relay, struct ccnl_content_s *c);
+
 #endif //CCNL_RELAY_H
 /** @} */

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -39,6 +39,12 @@
  * caching strategy removal function
  */
 static ccnl_cache_strategy_func _cs_remove_func = NULL;
+
+/**
+ * caching strategy decision function
+ */
+static ccnl_cache_strategy_func _cs_decision_func = NULL;
+
 struct ccnl_face_s*
 ccnl_get_face_or_create(struct ccnl_relay_s *ccnl, int ifndx,
                         struct sockaddr *sa, size_t addrlen)
@@ -1067,6 +1073,12 @@ ccnl_set_cache_strategy_remove(ccnl_cache_strategy_func func)
     _cs_remove_func = func;
 }
 
+void
+ccnl_set_cache_strategy_cache(ccnl_cache_strategy_func func)
+{
+    _cs_decision_func = func;
+}
+
 int
 cache_strategy_remove(struct ccnl_relay_s *relay, struct ccnl_content_s *c)
 {
@@ -1074,4 +1086,14 @@ cache_strategy_remove(struct ccnl_relay_s *relay, struct ccnl_content_s *c)
         return _cs_remove_func(relay, c);
     }
     return 0;
+}
+
+int
+cache_strategy_cache(struct ccnl_relay_s *relay, struct ccnl_content_s *c)
+{
+    if (_cs_decision_func) {
+        return _cs_decision_func(relay, c);
+    }
+    // If no caching decision strategy is defined, cache everything
+    return 1;
 }

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -562,7 +562,8 @@ ccnl_content_add2cache(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
     }
 
     if (ccnl->max_cache_entries > 0 &&
-        ccnl->contentcnt >= ccnl->max_cache_entries) { // remove oldest content
+        ccnl->contentcnt >= ccnl->max_cache_entries && !cache_strategy_remove(ccnl, c)) {
+        // remove oldest content
         struct ccnl_content_s *c2, *oldest = NULL;
         uint32_t age = 0;
         for (c2 = ccnl->contents; c2; c2 = c2->next) {

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -35,6 +35,10 @@
 
 
 
+/**
+ * caching strategy removal function
+ */
+static ccnl_cache_strategy_func _cs_remove_func = NULL;
 struct ccnl_face_s*
 ccnl_get_face_or_create(struct ccnl_relay_s *ccnl, int ifndx,
                         struct sockaddr *sa, size_t addrlen)
@@ -1054,4 +1058,19 @@ ccnl_cs_lookup(struct ccnl_relay_s *ccnl, char *prefix)
         ccnl_free(spref);
     }
     return NULL;
+}
+
+void
+ccnl_set_cache_strategy_remove(ccnl_cache_strategy_func func)
+{
+    _cs_remove_func = func;
+}
+
+int
+cache_strategy_remove(struct ccnl_relay_s *relay, struct ccnl_content_s *c)
+{
+    if (_cs_remove_func) {
+        return _cs_remove_func(relay, c);
+    }
+    return 0;
 }

--- a/src/ccnl-fwd/src/ccnl-fwd.c
+++ b/src/ccnl-fwd/src/ccnl-fwd.c
@@ -109,7 +109,7 @@ ccnl_fwd_handleContent(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
         return 0;
     }
 
-    if (relay->max_cache_entries != 0) { // it's set to -1 or a limit
+    if (relay->max_cache_entries != 0 && cache_strategy_cache(relay,c)) {
         DEBUGMSG_CFWD(DEBUG, "  adding content to cache\n");
         ccnl_content_add2cache(relay, c);
         int contlen = (int) (c->pkt->contlen > INT_MAX ? INT_MAX : c->pkt->contlen);

--- a/src/ccnl-lnxkernel/ccn-lite-lnxkernel.c
+++ b/src/ccnl-lnxkernel/ccn-lite-lnxkernel.c
@@ -121,6 +121,7 @@
 #define ccnl_app_RX(x,y)                do{}while(0)
 
 #define cache_strategy_remove(...)      0
+#define cache_strategy_cache(...)       0
 
 
 

--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -163,12 +163,6 @@ extern struct ccnl_relay_s ccnl_relay;
 extern evtimer_msg_t ccnl_evtimer;
 
 /**
- * @brief Function pointer type for caching strategy function
- */
-typedef int (*ccnl_cache_strategy_func)(struct ccnl_relay_s *relay,
-                                        struct ccnl_content_s *c);
-
-/**
  * @brief   Start the main CCN-Lite event-loop
  *
  * @return  The PID of the event-loop's thread
@@ -222,21 +216,6 @@ int ccnl_send_interest(struct ccnl_prefix_s *prefix,
  * @return -ETIMEDOUT if no chunk was received until timeout
  */
 int ccnl_wait_for_chunk(void *buf, size_t buf_len, uint64_t timeout);
-
-/**
- * @brief Set a function to control the caching strategy
- *
- * The given function will be called if the cache is full and a new content
- * chunk arrives. It shall remove (at least) one entry from the cache.
- *
- * If the return value of @p func is 0, the default caching strategy will be
- * applied by the CCN-lite stack. If the return value is 1, it is assumed that
- * (at least) one entry has been removed from the cache.
- *
- * @param[in] func  The function to be called for an incoming content chunk if
- *                  the cache is full.
- */
-void ccnl_set_cache_strategy_remove(ccnl_cache_strategy_func func);
 
 /**
  * @brief Send a message to the CCN-lite thread to add @p to the content store

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -46,11 +46,6 @@
 #include "ccnl-pkt-builder.h"
 
 /**
- * @brief May be defined for a particular caching strategy
- */
-int cache_strategy_remove(struct ccnl_relay_s *relay, struct ccnl_content_s *c);
-
-/**
  * @brief RIOT specific local variables
  * @{
  */
@@ -64,11 +59,6 @@ static msg_t _msg_queue[CCNL_QUEUE_SIZE];
  * @brief stack for the CCN-Lite eventloop
  */
 static char _ccnl_stack[CCNL_STACK_SIZE];
-
-/**
- * caching strategy removal function
- */
-static ccnl_cache_strategy_func _cs_remove_func = NULL;
 
 /**
  * currently configured suite
@@ -594,19 +584,4 @@ ccnl_send_interest(struct ccnl_prefix_s *prefix, unsigned char *buf, int buf_len
     }
 
     return ret;
-}
-
-void
-ccnl_set_cache_strategy_remove(ccnl_cache_strategy_func func)
-{
-    _cs_remove_func = func;
-}
-
-int
-cache_strategy_remove(struct ccnl_relay_s *relay, struct ccnl_content_s *c)
-{
-    if (_cs_remove_func) {
-        return _cs_remove_func(relay, c);
-    }
-    return 0;
 }


### PR DESCRIPTION
### Contribution description

This PR enables users to easily define their own caching decision and cache replacement strategies.

A quick note on terminology:

* The _caching decision strategy_ defines how a router decides whether or not to store an incoming chunk in the CS. The default strategy in both the literature and in CCN-lite is to always cache everything. However, the caching decision strategy can be arbitrarily complex, ranging from simple probabilistic caching to advanced strategies involving properties of the device, content, network topology, etc. [[1]](https://ieeexplore.ieee.org/abstract/document/7080842)
* The _cache replacement strategy_ is consulted after the caching decision strategy has decided in favour of caching the chunk and the CS is at capacity. It decides what old content chunk to evict. The default strategy in the literature and in CCN-lite is LRU, but it could be MRU, LFU, random, etc.

CCN-lite already provides an interface for user-defined cache replacement strategies using the `ccnl_set_cache_strategy_remove()` function in `ccn-lite-riot.c`. However, any user-defined strategies are not actually consulted in `ccnl_content_add2cache()`, which just applies LRU. This PR moves the relevant functions to `ccnl-relay.c` to make them accessible everywhere, not just in RIOT, and amends `ccnl_content_add2cache()` to consult the user-defined caching strategy. If there is no user-defined strategy, the default LRU is applied.

The caching decision strategy is implemented the same way. Use `ccnl_set_cache_strategy_cache()` to define a caching decision strategy that returns `1` if the content is to be cached and `0` otherwise. This caching decision strategy is consulted in `ccnl_fwd_handleContent()`. If no user-defined caching strategy exists, `1` is always returned, i.e. the content is always cached, just like before.

These changes do not modify the default behaviour if no user-defined strategies exist.