### PR TITLE
Use safe versions of string functions

### DIFF
--- a/src/ccn-lite-simu.c
+++ b/src/ccn-lite-simu.c
@@ -144,7 +144,7 @@ ccnl_simu_add2cache(char node, const char *name, int seqn, void *data, int len)
     if (!relay)
         return;
 
-    sprintf(tmp, "%s/.%d", name, seqn);
+    snprintf(tmp, sizeof(tmp), "%s/.%d", name, seqn);
     DEBUGMSG(VERBOSE, "  %s\n", tmp);
     //    p = ccnl_path_to_prefix(tmp);
     //    p->suite = suite;
@@ -177,7 +177,7 @@ ccnl_client_TX(char node, char *name, int seqn, int nonce)
     if (!relay)
         return;
 
-    sprintf(tmp, "%s/.%d", name, seqn);
+    snprintf(tmp, sizeof(tmp), "%s/.%d", name, seqn);
     //    p = ccnl_path_to_prefix(tmp);
     //    p->suite = suite;
     p = ccnl_URItoPrefix(tmp, theSuite, NULL, NULL);
@@ -464,7 +464,7 @@ ccnl_simu_init(int max_cache_entries, int mtu)
 */
 
     // turn node 'C' into a repository for three movies
-    sprintf(dat, "%d", (int) sizeof(dat));
+    snprintf(dat, SIMU_CHUNK_SIZE, "%d", (int) sizeof(dat));
     for (i = 0; i < SIMU_NUMBER_OF_CHUNKS; i++) {
         ccnl_simu_add2cache('C', "/ccnl/simu/movie1", i, dat, sizeof(dat));
         ccnl_simu_add2cache('C', "/ccnl/simu/movie2", i, dat, sizeof(dat));

--- a/src/ccnl-android/native/src/ccn-lite-android.c
+++ b/src/ccnl-android/native/src/ccn-lite-android.c
@@ -675,7 +675,7 @@ ccnl_android_init()
                         strlen(secret_key), keyid);
 #endif
 
-    sprintf(hello, "ccn-lite-android, %s",
+    snprintf(hello, sizeof(hello), "ccn-lite-android, %s",
             ctime(&theRelay.startup_time) + 4);
 
     return hello;
@@ -713,12 +713,12 @@ ccnl_android_getTransport()
         struct ifreq *r = &ifr[i];
         struct sockaddr_in *sin = (struct sockaddr_in *)&r->ifr_addr;
         if (strcmp(r->ifr_name, "lo")) {
-            sprintf(addr, "(%s)  UDP    ", ifr[i].ifr_name);
+            snprintf(addr, sizeof(addr), "(%s)  UDP    ", ifr[i].ifr_name);
             for (i = 0; i < theRelay.ifcount; i++) {
                 if (theRelay.ifs[i].addr.sa.sa_family != AF_INET)
                     continue;
                 sin->sin_port = theRelay.ifs[i].addr.ip4.sin_port;
-                sprintf(addr + strlen(addr), "%s    ",
+                snprintf(addr + strlen(addr), sizeof(addr) - strlen(addr), "%s    ",
                         ccnl_addr2ascii((sockunion*)sin));
             }
             ccnl_free(ifr);

--- a/src/ccnl-android/native/src/ccn-lite-android.c
+++ b/src/ccnl-android/native/src/ccn-lite-android.c
@@ -327,7 +327,7 @@ ccnl_populate_cache(struct ccnl_relay_s *ccnl, char *path)
 
         strncpy(fname, path, sizeof(fname));
         strcat(fname, "/");
-        strcat(fname, de->d_name);
+        strncat(fname, de->d_name, sizeof(fname) - strlen(fname) - 1);
 
         if (stat(fname, &s)) {
             perror("stat");

--- a/src/ccnl-android/native/src/ccn-lite-android.c
+++ b/src/ccnl-android/native/src/ccn-lite-android.c
@@ -325,7 +325,7 @@ ccnl_populate_cache(struct ccnl_relay_s *ccnl, char *path)
         if (de->d_name[0] == '.')
             continue;
 
-        strcpy(fname, path);
+        strncpy(fname, path, sizeof(fname));
         strcat(fname, "/");
         strcat(fname, de->d_name);
 
@@ -657,12 +657,12 @@ ccnl_android_init()
     ccnl_populate_cache(&theRelay, "/mnt/sdcard/ccn-lite");
 #ifdef USE_ECHO
 #ifdef USE_SUITE_CCNTLV
-    strcpy(hello, echopath);
+    strncpy(hello, echopath, sizeof(hello));
     echoprefix = ccnl_URItoPrefix(hello, CCNL_SUITE_CCNTLV, &dummy);
     ccnl_echo_add(&theRelay, echoprefix);
 #endif
 #ifdef USE_SUITE_NDNTLV
-    strcpy(hello, echopath);
+    strncpy(hello, echopath, sizeof(hello));
     echoprefix = ccnl_URItoPrefix(hello, CCNL_SUITE_NDNTLV, NULL);
     ccnl_echo_add(&theRelay, echoprefix);
 #endif

--- a/src/ccnl-android/native/src/ccn-lite-jni.c
+++ b/src/ccnl-android/native/src/ccn-lite-jni.c
@@ -105,7 +105,7 @@ add_route(char *pfx, struct ccnl_face_s *face, int suite, int mtu)
     DEBUGMSG(INFO, "adding a route for prefix %s (%s)\n",
              pfx, ccnl_suite2str(suite));
 
-    strcpy(buf, pfx);
+    strncpy(buf, pfx, sizeof(buf));
     fwd->prefix = ccnl_URItoPrefix(buf, suite, NULL);
     fwd->face = face;
 #ifdef USE_FRAG

--- a/src/ccnl-core/include/ccnl-logging.h
+++ b/src/ccnl-core/include/ccnl-logging.h
@@ -118,10 +118,10 @@ ccnl_debug_str2level(char *s);
 
 #  define DEBUGMSG(LVL, ...) do { int len;          \
         if ((LVL)>debug_level) break;               \
-        len = sprintf(android_logstr, "[%c] %s: ",  \
+        len = snprintf(android_logstr, sizeof(android_logstr), "[%c] %s: ",  \
             ccnl_debugLevelToChar(LVL),             \
             timestamp());                           \
-        len += sprintf(android_logstr+len, __VA_ARGS__);   \
+        len += snprintf(android_logstr+len, sizeof(android_logstr)-len, __VA_ARGS__);   \
         jni_append_to_log(android_logstr);          \
     } while (0)
 
@@ -215,7 +215,7 @@ debug_memdump(void);
 static char android_logstr[1024];
 void jni_append_to_log(char *line);
 
-#  define CONSOLE(...)        do { sprintf(android_logstr, __VA_ARGS__); \
+#  define CONSOLE(...)        do { snprintf(android_logstr, sizeof(android_logstr), __VA_ARGS__); \
                                    jni_append_to_log(android_logstr); \
                               } while(0)
 #  define CONSTSTR(s)         s

--- a/src/ccnl-core/src/ccnl-crypto.c
+++ b/src/ccnl-core/src/ccnl-crypto.c
@@ -113,8 +113,8 @@ ccnl_crypto_create_ccnl_sign_verify_msg(char *typ, int txid, char *content, int 
     // prepare FACEINSTANCE
     len3 += ccnl_ccnb_mkStrBlob(component_buf+len3, CCNL_DTAG_CALLBACK, CCN_TT_DTAG, callback);
     len3 += ccnl_ccnb_mkStrBlob(component_buf+len3, CCN_DTAG_TYPE, CCN_TT_DTAG, typ);
-    memset(h, 0, 100);
-    sprintf(h, "%d", txid);
+    memset(h, 0, sizeof(h));
+    snprintf(h, sizeof(h), "%d", txid);
     len3 += ccnl_ccnb_mkStrBlob(component_buf+len3, CCN_DTAG_SEQNO, CCN_TT_DTAG, h);
     if(!strcmp(typ, "verify"))
         len3 += ccnl_ccnb_mkBlob(component_buf+len3, CCN_DTAG_SIGNATURE, CCN_TT_DTAG,  // content
@@ -470,7 +470,7 @@ ccnl_mgmt_crypto(struct ccnl_relay_s *ccnl, char *type, unsigned char *buf, int 
           prefix_a->compcnt = 2;
           prefix_a->comp = (unsigned char **) ccnl_malloc(sizeof(unsigned char*)*2);
           prefix_a->comp[0] = "mgmt";
-          sprintf(ht, "seqnum-%d", -seqnum);
+          snprintf(ht, 20, "seqnum-%d", -seqnum);
           prefix_a->comp[1] = ht;
           prefix_a->complen = (int *) ccnl_malloc(sizeof(int)*2);
           prefix_a->complen[0] = strlen("mgmt");

--- a/src/ccnl-core/src/ccnl-crypto.c
+++ b/src/ccnl-core/src/ccnl-crypto.c
@@ -85,7 +85,7 @@ ccnl_crypto_create_ccnl_crypto_face(struct ccnl_relay_s *relay, char *ux_path)
     sockunion su;
     DEBUGMSG(DEBUG, "  adding UNIX face unixsrc=%s\n", ux_path);
     su.sa.sa_family = AF_UNIX;
-    strcpy(su.ux.sun_path, (char*) ux_path);
+    strncpy(su.ux.sun_path, (char*) ux_path, sizeof(su.ux.sun_path));
     relay->crypto_face = ccnl_get_face_or_create(relay, -1, &su.sa, sizeof(struct sockaddr_un));
     if(!relay->crypto_face) return 0;
     relay->crypto_face->flags = CCNL_FACE_FLAGS_STATIC;

--- a/src/ccnl-core/src/ccnl-dump.c
+++ b/src/ccnl-core/src/ccnl-dump.c
@@ -323,7 +323,7 @@ int get_prefix_dump(int lev, void *p, int *len, char** val)
     if (pre) {
 //    INDENT(lev);
         *len = pre->compcnt;
-        sprintf(*val, "%s", ccnl_prefix_to_str(pre,s,CCNL_MAX_PREFIX_SIZE));
+        snprintf(*val, CCNL_MAX_PREFIX_SIZE, "%s", ccnl_prefix_to_str(pre,s,CCNL_MAX_PREFIX_SIZE));
         return 1;
     }
 

--- a/src/ccnl-core/src/ccnl-http-status.c
+++ b/src/ccnl-core/src/ccnl-http-status.c
@@ -211,13 +211,13 @@ ccnl_http_status(struct ccnl_relay_s *ccnl, struct ccnl_http_s *http)
     char s[CCNL_MAX_PREFIX_SIZE];
 
     strcpy(txt, hdr);
-    len += sprintf(txt+len,
+    len += snprintf(txt+len, sizeof(txt) - len,
                    "<html><head><title>ccn-lite-relay status</title>\n"
                    "<style type=\"text/css\">\n"
                    "body {font-family: sans-serif;}\n"
                    "</style>\n"
                    "</head><body>\n");
-    len += sprintf(txt+len, "\n<table borders=0>\n<tr><td>"
+    len += snprintf(txt+len, sizeof(txt) - len, "\n<table borders=0>\n<tr><td>"
                    "<a href=\"\">[refresh]</a>&nbsp;&nbsp;<td>"
                    "ccn-lite-relay Status Page &nbsp;&nbsp;");
     //uname(&uts);
@@ -226,12 +226,12 @@ ccnl_http_status(struct ccnl_relay_s *ccnl, struct ccnl_http_s *http)
     t = time(NULL);
     cp = ctime(&t);
     cp[strlen(cp)-1] = 0;
-    len += sprintf(txt+len, "<tr><td><td><font size=-1>%s &nbsp;&nbsp;", cp);
+    len += snprintf(txt+len, sizeof(txt) - len, "<tr><td><td><font size=-1>%s &nbsp;&nbsp;", cp);
     cp = ctime(&ccnl->startup_time);
     cp[strlen(cp)-1] = 0;
-    len += sprintf(txt+len, " (started %s)</font>\n</table>\n", cp);
+    len += snprintf(txt+len, sizeof(txt) - len, " (started %s)</font>\n</table>\n", cp);
 
-    len += sprintf(txt+len, "\n<p><table borders=0 width=100%% bgcolor=#e0e0ff>"
+    len += snprintf(txt+len, sizeof(txt) - len, "\n<p><table borders=0 width=100%% bgcolor=#e0e0ff>"
                    "<tr><td><em>Forwarding table</em></table><ul>\n");
     for (fwd = ccnl->fib, cnt = 0; fwd; fwd = fwd->next, cnt++);
     if (cnt > 0) {
@@ -248,18 +248,18 @@ ccnl_http_status(struct ccnl_relay_s *ccnl, struct ccnl_http_s *http)
             else
 #endif
             if(fwda[i]->face)
-                sprintf(fname, "f%d", fwda[i]->face->faceid);
+                snprintf(fname, sizeof(fname), "f%d", fwda[i]->face->faceid);
             else
                 sprintf(fname, "?");
-            len += sprintf(txt+len,
+            len += snprintf(txt+len, sizeof(txt) - len,
                            "<li>via %4s: <font face=courier>%s</font>\n",
                            fname, ccnl_prefix_to_str(fwda[i]->prefix,s,CCNL_MAX_PREFIX_SIZE));
         }
         ccnl_free(fwda);
     }
-    len += sprintf(txt+len, "</ul>\n");
+    len += snprintf(txt+len, sizeof(txt) - len, "</ul>\n");
 
-    len += sprintf(txt+len, "\n<p><table borders=0 width=100%% bgcolor=#e0e0ff>"
+    len += snprintf(txt+len, sizeof(txt) - len, "\n<p><table borders=0 width=100%% bgcolor=#e0e0ff>"
                    "<tr><td><em>Faces</em></table><ul>\n");
     for (f = ccnl->faces, cnt = 0; f; f = f->next, cnt++);
     if (cnt > 0) {
@@ -269,28 +269,28 @@ ccnl_http_status(struct ccnl_relay_s *ccnl, struct ccnl_http_s *http)
             fa[i] = f;
         qsort(fa, cnt, sizeof(f), ccnl_cmpfaceid);
         for (i = 0; i < cnt; i++) {
-            len += sprintf(txt+len,
+            len += snprintf(txt+len, sizeof(txt) - len,
                            "<li><strong>f%d</strong> (via i%d) &nbsp;"
                            "peer=<font face=courier>%s</font> &nbsp;ttl=",
                            fa[i]->faceid, fa[i]->ifndx,
                            ccnl_addr2ascii(&(fa[i]->peer)));
             if (fa[i]->flags & CCNL_FACE_FLAGS_STATIC)
-                len += sprintf(txt+len, "static");
+                len += snprintf(txt+len, sizeof(txt) - len, "static");
             else
-                len += sprintf(txt+len, "%.1fsec",
+                len += snprintf(txt+len, sizeof(txt) - len, "%.1fsec",
                         fa[i]->last_used + CCNL_FACE_TIMEOUT - CCNL_NOW());
             for (j = 0, bpt = fa[i]->outq; bpt; bpt = bpt->next, j++);
-            len += sprintf(txt+len, " &nbsp;qlen=%d\n", j);
+            len += snprintf(txt+len, sizeof(txt) - len, " &nbsp;qlen=%d\n", j);
         }
         ccnl_free(fa);
     }
-    len += sprintf(txt+len, "</ul>\n");
+    len += snprintf(txt+len, sizeof(txt) - len, "</ul>\n");
 
-    len += sprintf(txt+len, "\n<p><table borders=0 width=100%% bgcolor=#e0e0ff>"
+    len += snprintf(txt+len, sizeof(txt) - len, "\n<p><table borders=0 width=100%% bgcolor=#e0e0ff>"
                    "<tr><td><em>Interfaces</em></table><ul>\n");
     for (i = 0; i < ccnl->ifcount; i++) {
 #ifdef USE_STATS
-        len += sprintf(txt+len, "<li><strong>i%d</strong>&nbsp;&nbsp;"
+        len += snprintf(txt+len, sizeof(txt) - len, "<li><strong>i%d</strong>&nbsp;&nbsp;"
                        "addr=<font face=courier>%s</font>&nbsp;&nbsp;"
                        "qlen=%zu/%d"
                        "&nbsp;&nbsp;rx=%u&nbsp;&nbsp;tx=%u"
@@ -299,7 +299,7 @@ ccnl_http_status(struct ccnl_relay_s *ccnl, struct ccnl_http_s *http)
                        ccnl->ifs[i].qlen, CCNL_MAX_IF_QLEN,
                        ccnl->ifs[i].rx_cnt, ccnl->ifs[i].tx_cnt);
 #else
-        len += sprintf(txt+len, "<li><strong>i%d</strong>&nbsp;&nbsp;"
+        len += snprintf(txt+len, sizeof(txt) - len, "<li><strong>i%d</strong>&nbsp;&nbsp;"
                        "addr=<font face=courier>%s</font>&nbsp;&nbsp;"
                        "qlen=%d/%d"
                        "\n",
@@ -307,40 +307,40 @@ ccnl_http_status(struct ccnl_relay_s *ccnl, struct ccnl_http_s *http)
                        ccnl->ifs[i].qlen, CCNL_MAX_IF_QLEN);
 #endif
     }
-    len += sprintf(txt+len, "</ul>\n");
+    len += snprintf(txt+len, sizeof(txt) - len, "</ul>\n");
 
-    len += sprintf(txt+len, "\n<p><table borders=0 width=100%% bgcolor=#e0e0ff>"
+    len += snprintf(txt+len, sizeof(txt) - len, "\n<p><table borders=0 width=100%% bgcolor=#e0e0ff>"
                    "<tr><td><em>Misc stats</em></table><ul>\n");
     for (cnt = 0, bpt = ccnl->nonces; bpt; bpt = bpt->next, cnt++);
-    len += sprintf(txt+len, "<li>Nonces: %d\n", cnt);
+    len += snprintf(txt+len, sizeof(txt) - len, "<li>Nonces: %d\n", cnt);
     for (cnt = 0, ipt = ccnl->pit; ipt; ipt = ipt->next, cnt++);
-    len += sprintf(txt+len, "<li>Pending interests: %d\n", cnt);
-    len += sprintf(txt+len, "<li>Content chunks: %d (max=%d)\n",
+    len += snprintf(txt+len, sizeof(txt) - len, "<li>Pending interests: %d\n", cnt);
+    len += snprintf(txt+len, sizeof(txt) - len, "<li>Content chunks: %d (max=%d)\n",
                    ccnl->contentcnt, ccnl->max_cache_entries);
-    len += sprintf(txt+len, "</ul>\n");
+    len += snprintf(txt+len, sizeof(txt) - len, "</ul>\n");
 
-    len += sprintf(txt+len, "\n<p><table borders=0 width=100%% bgcolor=#e0e0ff>"
+    len += snprintf(txt+len, sizeof(txt) - len, "\n<p><table borders=0 width=100%% bgcolor=#e0e0ff>"
                    "<tr><td><em>Config</em></table><table borders=0>\n");
-    len += sprintf(txt+len, "<tr><td>content.timeout:"
+    len += snprintf(txt+len, sizeof(txt) - len, "<tr><td>content.timeout:"
                    "<td align=right> %d<td>\n", CCNL_CONTENT_TIMEOUT);
-    len += sprintf(txt+len, "<tr><td>face.timeout:"
+    len += snprintf(txt+len, sizeof(txt) - len, "<tr><td>face.timeout:"
                    "<td align=right> %d<td>\n", CCNL_FACE_TIMEOUT);
-    len += sprintf(txt+len, "<tr><td>interest.maxretransmit:"
+    len += snprintf(txt+len, sizeof(txt) - len, "<tr><td>interest.maxretransmit:"
                    "<td align=right> %d<td>\n", CCNL_MAX_INTEREST_RETRANSMIT);
-    len += sprintf(txt+len, "<tr><td>interest.timeout:"
+    len += snprintf(txt+len, sizeof(txt) - len, "<tr><td>interest.timeout:"
                    "<td align=right> %d<td>\n", CCNL_INTEREST_TIMEOUT);
-    len += sprintf(txt+len, "<tr><td>nonces.max:"
+    len += snprintf(txt+len, sizeof(txt) - len, "<tr><td>nonces.max:"
                    "<td align=right> %d<td>\n", CCNL_MAX_NONCES);
 
     //len += sprintf(txt+len, "<tr><td>compile.featureset:<td><td> %s\n",
     //               compile_string);
-    len += sprintf(txt+len, "<tr><td>compile.time:"
+    len += snprintf(txt+len, sizeof(txt) - len, "<tr><td>compile.time:"
                    "<td><td>%s %s\n", __DATE__, __TIME__);
-    len += sprintf(txt+len, "<tr><td>compile.ccnl_core_version:"
+    len += snprintf(txt+len, sizeof(txt) - len, "<tr><td>compile.ccnl_core_version:"
                    "<td><td>%s\n", CCNL_VERSION);
-    len += sprintf(txt+len, "</table>\n");
+    len += snprintf(txt+len, sizeof(txt) - len, "</table>\n");
 
-    len += sprintf(txt+len, "\n<p><hr></body></html>\n");
+    len += snprintf(txt+len, sizeof(txt) - len, "\n<p><hr></body></html>\n");
 
     http->out = (unsigned char*) txt;
     http->outoffs = 0;

--- a/src/ccnl-core/src/ccnl-malloc.c
+++ b/src/ccnl-core/src/ccnl-malloc.c
@@ -66,7 +66,7 @@ void* debug_malloc(size_t s, const char *fn, int lno, char *tstamp)
             char *timestamp = malloc(new_timestamp_size); 
 
             if (timestamp) {
-                h->tstamp = strcpy(timestamp, tstamp); 
+                h->tstamp = strncpy(timestamp, tstamp, new_timestamp_size);
             /** allocating the timestamp failed */
             } else { 
                 /** free previously allocated memory */
@@ -198,7 +198,7 @@ void* debug_strdup(const char *s, const char *fn, int lno, char *tstamp)
             cp = (char*) debug_malloc(size, fn, lno, tstamp);
              
             if (cp) {
-                strcpy(cp, s);
+                strncpy(cp, s, size);
             }
         }
 #ifndef BUILTIN_INT_ADD_OVERFLOW_DETECTION_UNAVAILABLE

--- a/src/ccnl-core/src/ccnl-mgmt.c
+++ b/src/ccnl-core/src/ccnl-mgmt.c
@@ -240,7 +240,7 @@ ccnl_mgmt_send_return_split(struct ccnl_relay_s *ccnl, struct ccnl_buf_s *orig,
                 size_t contentpos;
 
                 DEBUGMSG(INFO, "  .. adding to cache %zu %zu bytes\n", len4, len5);
-                sprintf(uri, "/mgmt/seqnum-%zu", it);
+                snprintf(uri, sizeof(uri), "/mgmt/seqnum-%zu", it);
                 pkt = ccnl_calloc(1, sizeof(*pkt));
                 if (!pkt) {
                     goto Bail;
@@ -417,7 +417,7 @@ ccnl_mgmt_create_interface_stmt(size_t num_interfaces, int *interfaceifndx, long
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%d", interfaceifndx[it]);
+        snprintf(str, sizeof(str), "%d", interfaceifndx[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_IFNDX, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
@@ -433,24 +433,24 @@ ccnl_mgmt_create_interface_stmt(size_t num_interfaces, int *interfaceifndx, long
 
         memset(str, 0, sizeof(str));
         if (interfacedevtype[it] == 1) {
-            sprintf(str, "%p", (void *) interfacedev[it]);
+            snprintf(str, sizeof(str), "%p", (void *) interfacedev[it]);
             if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_ETH, CCN_TT_DTAG, str, len3)) {
                 return -1;
             }
         } else if(interfacedevtype[it] == 2) {
-            sprintf(str, "%p", (void *) interfacedev[it]);
+            snprintf(str, sizeof(str), "%p", (void *) interfacedev[it]);
             if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_SOCK, CCN_TT_DTAG, str, len3)) {
                 return -1;
             }
         } else {
-            sprintf(str, "%p", (void *) interfacedev[it]);
+            snprintf(str, sizeof(str), "%p", (void *) interfacedev[it]);
             if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_SOCK, CCN_TT_DTAG, str, len3)) {
                 return -1;
             }
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%d", interfacereflect[it]);
+        snprintf(str, sizeof(str), "%d", interfacereflect[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_REFLECT, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
@@ -478,31 +478,31 @@ ccnl_mgmt_create_faces_stmt(size_t num_faces, int *faceid, long *facenext,
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%d", faceid[it]);
+        snprintf(str, sizeof(str), "%d", faceid[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCN_DTAG_FACEID, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%p", (void *) facenext[it]);
+        snprintf(str, sizeof(str), "%p", (void *) facenext[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_NEXT, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str,"%p", (void *)faceprev[it]);
+        snprintf(str, sizeof(str), "%p", (void *)faceprev[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_PREV, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str,"%d", faceifndx[it]);
+        snprintf(str, sizeof(str), "%d", faceifndx[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_IFNDX, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str,"%02x", faceflags[it]);
+        snprintf(str, sizeof(str), "%02x", faceflags[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_FACEFLAGS, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
@@ -525,7 +525,7 @@ ccnl_mgmt_create_faces_stmt(size_t num_faces, int *faceid, long *facenext,
                 return -1;
             }
         } else {
-            sprintf(str,"peer=?");
+            snprintf(str, sizeof(str), "peer=?");
             if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_PEER, CCN_TT_DTAG, str, len3)) {
                 return -1;
             }
@@ -554,31 +554,31 @@ ccnl_mgmt_create_fwds_stmt(size_t num_fwds, long *fwd, long *fwdnext, long *fwdf
          }
 
          memset(str, 0, sizeof(str));
-         sprintf(str, "%p", (void *)fwd[it]);
+         snprintf(str, sizeof(str),  "%p", (void *)fwd[it]);
          if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_FWD, CCN_TT_DTAG, str, len3)) {
              return -1;
          }
 
          memset(str, 0, sizeof(str));
-         sprintf(str, "%p", (void *)fwdnext[it]);
+         snprintf(str, sizeof(str),  "%p", (void *)fwdnext[it]);
          if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_NEXT, CCN_TT_DTAG, str, len3)) {
              return -1;
          }
 
          memset(str, 0, sizeof(str));
-         sprintf(str, "%p", (void *)fwdface[it]);
+         snprintf(str, sizeof(str),  "%p", (void *)fwdface[it]);
          if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_FACE, CCN_TT_DTAG, str, len3)) {
              return -1;
          }
 
          memset(str, 0, sizeof(str));
-         sprintf(str, "%d", fwdfaceid[it]);
+         snprintf(str, sizeof(str),  "%d", fwdfaceid[it]);
          if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCN_DTAG_FACEID, CCN_TT_DTAG, str, len3)) {
              return -1;
          }
 
          memset(str, 0, sizeof(str));
-         sprintf(str, "%d", suite[it]);
+         snprintf(str, sizeof(str),  "%d", suite[it]);
          if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_SUITE, CCN_TT_DTAG, str, len3)) {
              return -1;
          }
@@ -611,49 +611,49 @@ ccnl_mgmt_create_interest_stmt(size_t num_interests, long *interest, long *inter
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%p", (void *) interest[it]);
+        snprintf(str, sizeof(str),  "%p", (void *) interest[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_INTERESTPTR, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%p", (void *) interestnext[it]);
+        snprintf(str, sizeof(str),  "%p", (void *) interestnext[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_NEXT, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%p", (void *) interestprev[it]);
+        snprintf(str, sizeof(str),  "%p", (void *) interestprev[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_PREV, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%d", interestlast[it]);
+        snprintf(str, sizeof(str),  "%d", interestlast[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_LAST, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%d", interestmin[it]);
+        snprintf(str, sizeof(str),  "%d", interestmin[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_MIN, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%d", interestmax[it]);
+        snprintf(str, sizeof(str),  "%d", interestmax[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_MAX, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%d", interestretries[it]);
+        snprintf(str, sizeof(str),  "%d", interestretries[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_RETRIES, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%p", (void *) interestpublisher[it]);
+        snprintf(str, sizeof(str),  "%p", (void *) interestpublisher[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_PUBLISHER, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
@@ -684,31 +684,31 @@ ccnl_mgmt_create_content_stmt(size_t num_contents, long *content, long *contentn
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%p", (void *) content[it]);
+        snprintf(str, sizeof(str),  "%p", (void *) content[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_CONTENTPTR, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%p", (void *) contentnext[it]);
+        snprintf(str, sizeof(str),  "%p", (void *) contentnext[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_NEXT, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%p", (void *) contentprev[it]);
+        snprintf(str, sizeof(str),  "%p", (void *) contentprev[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_PREV, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%d", contentlast_use[it]);
+        snprintf(str, sizeof(str),  "%d", contentlast_use[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_LASTUSE, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
 
         memset(str, 0, sizeof(str));
-        sprintf(str, "%d", contentserved_cnt[it]);
+        snprintf(str, sizeof(str),  "%d", contentserved_cnt[it]);
         if (ccnl_ccnb_mkStrBlob(stmt+*len3, stmtend, CCNL_DTAG_SERVEDCTN, CCN_TT_DTAG, str, len3)) {
             return -1;
         }
@@ -1542,7 +1542,7 @@ SoftBail:
         }
     }
     if (f) {
-        sprintf((char *)faceidstr,"%i",f->faceid);
+        snprintf((char *)faceidstr, sizeof(faceidstr), "%i",f->faceid);
         if (ccnl_ccnb_mkStrBlob(faceinst_buf+len3, faceinst_buf + FACEINST_BUF_SIZE, CCN_DTAG_FACEID, CCN_TT_DTAG, (char *) faceidstr, &len3)) {
             goto Bail;
         }
@@ -2425,7 +2425,7 @@ SoftBail:
 
     //    len3 += ccnl_ccnb_mkStrBlob(fwdentry_buf+len3, CCN_DTAG_FACEID, CCN_TT_DTAG, (char*) faceid);
     memset(h,0,sizeof(h));
-    sprintf((char*)h, "%d", (int)suite[0]);
+    snprintf((char*)h, sizeof(h), "%d", (int)suite[0]);
     if (ccnl_ccnb_mkStrBlob(fwdentry_buf+len3, fwdentry_buf + FWDENTRY_BUF_SIZE, CCNL_DTAG_SUITE, CCN_TT_DTAG, (char*) h, &len3)) {
         goto Bail;
     }
@@ -2640,7 +2640,7 @@ SoftBail:
         goto Bail;
     }
     memset(h,0,sizeof(h));
-    sprintf((char*)h, "%d", (int)suite[0]);
+    snprintf((char*)h, sizeof(h), "%d", (int)suite[0]);
     if (ccnl_ccnb_mkStrBlob(fwdentry_buf+len3, fwdentry_buf + FWDENTRY_BUF_SIZE, CCNL_DTAG_SUITE, CCN_TT_DTAG, (char*) h, &len3)) {
         goto Bail;
     }

--- a/src/ccnl-core/src/ccnl-os-time.c
+++ b/src/ccnl-core/src/ccnl-os-time.c
@@ -100,7 +100,7 @@ timestamp(void)
 {
     static char ts[16], *cp;
 
-    sprintf(ts, "%.4g", CCNL_NOW());
+    snprintf(ts, sizeof(ts), "%.4g", CCNL_NOW());
     cp = strchr(ts, '.');
     if (!cp)
         strcat(ts, ".0000");

--- a/src/ccnl-core/src/ccnl-sched.c
+++ b/src/ccnl-core/src/ccnl-sched.c
@@ -329,7 +329,7 @@ int cfnl_sched_create_default_rnet(struct ccnl_sched_s *sched, int inter_packet_
     }
 
     // create reaction network
-    sprintf(name, "%p", sched);
+    snprintf(name, sizeof(name), "%p", sched);
     sched->rn = cf_rnet_create(engine, name, cf_handle_null);
     if (!sched->rn)
         goto err_out;

--- a/src/ccnl-fwd/src/ccnl-echo.c
+++ b/src/ccnl-fwd/src/ccnl-echo.c
@@ -60,7 +60,7 @@ ccnl_echo_request(struct ccnl_relay_s *relay, struct ccnl_face_s *inface,
     ccnl_prefix_to_str(pfx,s,CCNL_MAX_PREFIX_SIZE);
 
     cp = ccnl_malloc(strlen(s) + 60);
-    sprintf(cp, "%s\n%suptime %s\n", s, ctime(&t), timestamp());
+    snprintf(cp, strlen(s) + 60, "%s\n%suptime %s\n", s, ctime(&t), timestamp());
 
     reply = ccnl_mkSimpleContent(pfx, (unsigned char*) cp, strlen(cp), 0, NULL);
     ccnl_free(cp);

--- a/src/ccnl-fwd/src/ccnl-localrpc.c
+++ b/src/ccnl-fwd/src/ccnl-localrpc.c
@@ -368,7 +368,7 @@ rpc_cacheRemove(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     }
     {
         char *p = ccnl_malloc(100);
-        sprintf(p, "rpc_cacheRemove: removed %d entries\n", cnt);
+        snprintf(p, 100, "rpc_cacheRemove: removed %d entries\n", cnt);
         ccnl_emit_RpcReturn(relay, from, nonce, 415, p, NULL);
         ccnl_free(p);
     }

--- a/src/ccnl-lnxkernel/ccn-lite-lnxkernel.c
+++ b/src/ccnl-lnxkernel/ccn-lite-lnxkernel.c
@@ -517,7 +517,7 @@ ccnl_open_unixpath(char *path, struct sockaddr_un *ux)
     DEBUGMSG(DEBUG, "UNIX socket is %p\n", (void*)s);
 
     ux->sun_family = AF_UNIX;
-    strcpy(ux->sun_path, path);
+    strncpy(ux->sun_path, path, sizeof(ux->sun_path));
     rc = s->ops->bind(s, (struct sockaddr*) ux,
                 offsetof(struct sockaddr_un, sun_path) + strlen(path) + 1);
     if (rc < 0) {

--- a/src/ccnl-lnxkernel/ccn-lite-lnxkernel.c
+++ b/src/ccnl-lnxkernel/ccn-lite-lnxkernel.c
@@ -150,7 +150,7 @@ inet_ntoa(struct in_addr in)
     static char buf[16];
     unsigned int i, len = 0, a = ntohl(in.s_addr);
     for (i = 0; i < 4; i++) {
-        len += sprintf(buf+len, "%s%d", i ? "." : "", 0xff & (a >> 8*(3-i)));
+        len += snprintf(buf+len, sizeof(buf)-len, "%s%d", i ? "." : "", 0xff & (a >> 8*(3-i)));
     }
     return buf;
 }
@@ -689,7 +689,7 @@ ccnl_init(void)
         theRelay.crypto_path = p;
         //Reply socket
         i = &theRelay.ifs[theRelay.ifcount];
-        sprintf(h, "%s-2", p);
+        snprintf(h, sizeof(h), "%s-2", p);
         i->sock = ccnl_open_unixpath(h, &i->addr.ux);
         if (i->sock) {
             DEBUGMSG(DEBUG, "ccnl_open_unixpath worked\n");

--- a/src/ccnl-unix/src/ccnl-unix.c
+++ b/src/ccnl-unix/src/ccnl-unix.c
@@ -704,7 +704,7 @@ ccnl_populate_cache(struct ccnl_relay_s *ccnl, char *path)
 
         strncpy(fname, path, sizeof(fname));
         strcat(fname, "/");
-        strcat(fname, de->d_name);
+        strncat(fname, de->d_name, sizeof(fname) - strlen(fname) - 1);
 
         if (stat(fname, &s)) {
             perror("stat");

--- a/src/ccnl-unix/src/ccnl-unix.c
+++ b/src/ccnl-unix/src/ccnl-unix.c
@@ -135,7 +135,7 @@ ccnl_open_unixpath(char *path, struct sockaddr_un *ux)
 
     unlink(path);
     ux->sun_family = AF_UNIX;
-    strcpy(ux->sun_path, path);
+    strncpy(ux->sun_path, path, sizeof(ux->sun_path));
 
     if (bind(sock, (struct sockaddr *) ux, sizeof(struct sockaddr_un))) {
         perror("binding name to datagram socket");
@@ -225,7 +225,7 @@ ccnl_eth_sendto(int sock, uint8_t *dst, uint8_t *src,
     size_t hdrlen;
 
 #ifdef USE_DEBUG
-    strcpy((char*)buf, ll2ascii(dst, 6));
+    strncpy((char*)buf, ll2ascii(dst, 6), sizeof(buf));
     DEBUGMSG(TRACE, "ccnl_eth_sendto %zu bytes (src=%s, dst=%s)\n",
              datalen, ll2ascii(src, 6), buf);
 #endif
@@ -702,7 +702,7 @@ ccnl_populate_cache(struct ccnl_relay_s *ccnl, char *path)
             continue;
         }
 
-        strcpy(fname, path);
+        strncpy(fname, path, sizeof(fname));
         strcat(fname, "/");
         strcat(fname, de->d_name);
 

--- a/src/ccnl-unix/src/ccnl-unix.c
+++ b/src/ccnl-unix/src/ccnl-unix.c
@@ -538,7 +538,7 @@ ccnl_relay_config(struct ccnl_relay_s *relay, char *ethdev, char *wpandev,
 
         //receiving interface
         memset(h,0,sizeof(h));
-        sprintf(h,"%s-2",crypto_face_path);
+        snprintf(h, sizeof(h), "%s-2",crypto_face_path);
         i = &relay->ifs[relay->ifcount];
         i->sock = ccnl_open_unixpath(h, &i->addr.ux);
         i->mtu = 4096;

--- a/src/ccnl-utils/src/ccn-lite-cryptoserver.c
+++ b/src/ccnl-utils/src/ccn-lite-cryptoserver.c
@@ -168,7 +168,7 @@ handle_verify(uint8_t **buf, size_t *buflen, int sock, char *callback){
         goto Bail;
     }
     memset(h,0,sizeof(h));
-    sprintf(h,"%d", verified);
+    snprintf(h, sizeof(h), "%d", verified);
     if (ccnl_ccnb_mkStrBlob(component_buf+len3, component_buf + complen, CCNL_DTAG_VERIFIED, CCN_TT_DTAG, h, &len3)) {
         goto Bail;
     }

--- a/src/ccnl-utils/src/ccn-lite-cryptoserver.c
+++ b/src/ccnl-utils/src/ccn-lite-cryptoserver.c
@@ -62,7 +62,7 @@ ccnl_crypto_ux_open(char *frompath)
     }
     unlink(frompath);
     name.sun_family = AF_UNIX;
-    strcpy(name.sun_path, frompath);
+    strncpy(name.sun_path, frompath, sizeof(name.sun_path));
     if (bind(sock, (struct sockaddr *) &name,
              sizeof(struct sockaddr_un))) {
         perror("\tbinding name to datagram socket");

--- a/src/ccnl-utils/src/ccn-lite-ctrl.c
+++ b/src/ccnl-utils/src/ccn-lite-ctrl.c
@@ -1181,7 +1181,7 @@ mkAddToRelayCacheRequest(uint8_t *out, size_t outlen, char *fname,
     }
 
     memset(h, '\0', sizeof(h));
-    sprintf((char*)h, "%d", *suite);
+    snprintf((char*)h, sizeof(h), "%d", *suite);
     if (ccnl_ccnb_mkBlob(contentobj+len2, contentobj + 4000, CCNL_DTAG_SUITE, CCN_TT_DTAG,  // suite
                              (char*) h, strlen((char*)h), &len2)) {
         goto Bail;
@@ -1199,14 +1199,14 @@ mkAddToRelayCacheRequest(uint8_t *out, size_t outlen, char *fname,
     }
 
     memset(h, '\0', sizeof(h));
-    sprintf((char*)h, "%d", *prefix->chunknum);
+    snprintf((char*)h, sizeof(h), "%d", *prefix->chunknum);
     if (ccnl_ccnb_mkBlob(contentobj+len2, contentobj + 4000, CCNL_DTAG_CHUNKNUM, CCN_TT_DTAG,  // chunknum
                             (char*) h, strlen((char*)h), &len2)) {
         goto Bail;
     }
 
     memset(h, '\0', sizeof(h));
-    sprintf((char*)h, "%d", chunkflag);
+    snprintf((char*)h, sizeof(h), "%d", chunkflag);
     if (ccnl_ccnb_mkBlob(contentobj+len2, contentobj + 4000, CCNL_DTAG_CHUNKFLAG, CCN_TT_DTAG,  // chunkflag
                             (char*) h, strlen((char*)h), &len2)) {
         goto Bail;
@@ -1440,7 +1440,7 @@ make_next_seg_debug_interest(int num, uint8_t *out, size_t outlen, size_t *resle
     size_t len = 0;
     unsigned char cp[100];
 
-    sprintf((char*)cp, "seqnum-%d", num);
+    snprintf((char*)cp, sizeof(cp), "seqnum-%d", num);
 
     if (ccnl_ccnb_mkHeader(out, out + outlen, CCN_DTAG_INTEREST, CCN_TT_DTAG, &len)) {  // interest
         return -1;
@@ -1848,7 +1848,7 @@ help:
         int hasNext = 0;
 
         // socket for receiving
-        sprintf(mysockname, "/tmp/.ccn-light-ctrl-%d.sock", getpid());
+        snprintf(mysockname, sizeof(mysockname), "/tmp/.ccn-light-ctrl-%d.sock", getpid());
 
         if (!use_udp) {
             sock = ccnl_crypto_ux_open(mysockname);
@@ -1935,13 +1935,13 @@ help:
             char sigoutput[200];
 
             if (verified) {
-                sprintf(sigoutput, "All parts (%d) have been verified", numOfParts);
+                snprintf(sigoutput, sizeof(sigoutput), "All parts (%d) have been verified", numOfParts);
                 if (ccnl_ccnb_mkStrBlob(recvbuffer2+recvbufferlen2, recvbuffer2 + sizeof(char) * recvbufferlen +1000,
                                         CCN_DTAG_SIGNATURE, CCN_TT_DTAG, sigoutput, &recvbufferlen2)) {
                     goto Bail;
                 }
             } else {
-                sprintf(sigoutput, "NOT all parts (%d) have been verified", numOfParts);
+                snprintf(sigoutput, sizeof(sigoutput), "NOT all parts (%d) have been verified", numOfParts);
                 if (ccnl_ccnb_mkStrBlob(recvbuffer2+recvbufferlen2, recvbuffer2 + sizeof(char) * recvbufferlen +1000,
                                         CCN_DTAG_SIGNATURE, CCN_TT_DTAG, sigoutput, &recvbufferlen2)) {
                     goto Bail;

--- a/src/ccnl-utils/src/ccn-lite-ctrl.c
+++ b/src/ccnl-utils/src/ccn-lite-ctrl.c
@@ -1383,7 +1383,7 @@ ccnl_crypto_ux_open(char *frompath)
     }
     unlink(frompath);
     name.sun_family = AF_UNIX;
-    strcpy(name.sun_path, frompath);
+    strncpy(name.sun_path, frompath, sizeof(name.sun_path));
     if (bind(sock, (struct sockaddr *) &name,
             sizeof(struct sockaddr_un))) {
         perror("binding name to datagram socket");
@@ -1422,7 +1422,7 @@ int ux_sendto2(int sock, char *topath, unsigned char *data, size_t len)
 
     /* Construct name of socket to send to. */
     name.sun_family = AF_UNIX;
-    strcpy(name.sun_path, topath);
+    strncpy(name.sun_path, topath, sizeof(name.sun_path));
 
     /* Send message. */
     rc = sendto(sock, data, len, 0, (struct sockaddr*) &name,

--- a/src/ccnl-utils/src/ccn-lite-deF.c
+++ b/src/ccnl-utils/src/ccn-lite-deF.c
@@ -45,7 +45,7 @@ reassembly_done(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
     char fname[512];
     int f;
 
-    sprintf(fname, "%s%03d.ccnb", fileprefix, cnt);
+    snprintf(fname, sizeof(fname), "%s%03d.ccnb", fileprefix, cnt);
     if (noclobber && !access(fname, F_OK)) {
         printf("file %s already exists, exiting\n", fname);
         exit(-1);

--- a/src/ccnl-utils/src/ccn-lite-fetch.c
+++ b/src/ccnl-utils/src/ccn-lite-fetch.c
@@ -252,7 +252,7 @@ usage:
     if (ux) { // use UNIX socket
         struct sockaddr_un *su = (struct sockaddr_un*) &sa;
         su->sun_family = AF_UNIX;
-        strcpy(su->sun_path, ux);
+        strncpy(su->sun_path, ux, sizeof(su->sun_path));
         sock = ux_open();
     } else { // UDP
         struct sockaddr_in *si = (struct sockaddr_in*) &sa;

--- a/src/ccnl-utils/src/ccn-lite-mkF.c
+++ b/src/ccnl-utils/src/ccn-lite-mkF.c
@@ -48,7 +48,7 @@ file2frags(int suite, unsigned char *data, int datalen, char *fileprefix,
     //    fragbuf = ccnl_frag_getnext(&fr);
     fragbuf = ccnl_frag_getnext(&fr, NULL, NULL);
     while (fragbuf) {
-        sprintf(fname, "%s%03d.frag", fileprefix, cnt);
+        snprintf(fname, sizeof(fname), "%s%03d.frag", fileprefix, cnt);
         if (noclobber && !access(fname, F_OK)) {
             printf("file %s already exists, skipping this name\n", fname);
         } else {

--- a/src/ccnl-utils/src/ccn-lite-peek.c
+++ b/src/ccnl-utils/src/ccn-lite-peek.c
@@ -129,7 +129,7 @@ usage:
     if (ux) { // use UNIX socket
         struct sockaddr_un *su = (struct sockaddr_un*) &sa;
         su->sun_family = AF_UNIX;
-        strcpy(su->sun_path, ux);
+        strncpy(su->sun_path, ux, sizeof(su->sun_path));
         sock = ux_open();
     } else { // UDP
         struct sockaddr_in *si = (struct sockaddr_in*) &sa;

--- a/src/ccnl-utils/src/ccn-lite-pktdump.c
+++ b/src/ccnl-utils/src/ccn-lite-pktdump.c
@@ -559,7 +559,7 @@ ccntlv_parse_sequence(size_t lev, uint16_t ctx, unsigned char *base,
             }
             *len -= vallen;
             i = vallen;
-            strcpy(n_old, n);
+            strncpy(n_old, n, sizeof(n_old));
             if (ccntlv_parse_sequence(lev+1, ctx2, base, buf, &i, n, rawxml, out)) {
                 return -1;
             }

--- a/src/ccnl-utils/src/ccn-lite-pktdump.c
+++ b/src/ccnl-utils/src/ccn-lite-pktdump.c
@@ -491,13 +491,13 @@ ccnl_ccntlv_type2name(uint16_t ctx, uint16_t type, int rawxml)
     }
     if (tn) {
         if(!rawxml)
-            sprintf(tmp, "%s\\%s", tn, cn);
+            snprintf(tmp, sizeof(tmp), "%s\\%s", tn, cn);
         else
-            sprintf(tmp, "%s", tn);
+            snprintf(tmp, sizeof(tmp), "%s", tn);
     } else if (cn) {
-        sprintf(tmp, "type=0x%04x\\%s", type, cn);
+        snprintf(tmp, sizeof(tmp), "type=0x%04x\\%s", type, cn);
     } else {
-        sprintf(tmp, "type=0x%04x\\ctx=%d", type, ctx);
+        snprintf(tmp, sizeof(tmp), "type=0x%04x\\ctx=%d", type, ctx);
     }
     return tmp;
 }
@@ -529,7 +529,7 @@ ccntlv_parse_sequence(size_t lev, uint16_t ctx, unsigned char *base,
 
         n = ccnl_ccntlv_type2name(ctx, typ, rawxml);
         if (!n) {
-            sprintf(tmp, "type=%hu", typ);
+            snprintf(tmp, sizeof(tmp), "type=%hu", typ);
             n = tmp;
         }
 
@@ -822,7 +822,7 @@ ndn_parse_sequence(size_t lev, uint8_t *base, uint8_t **buf,
 
         n = ndn_type2name(typ);
         if (!n) {
-            sprintf(tmp, "type=%lu", typ);
+            snprintf(tmp, sizeof(tmp), "type=%lu", typ);
             n = tmp;
         }
 
@@ -987,7 +987,7 @@ localrpc_parse(size_t lev, uint8_t *base, uint8_t **buf, size_t *len,
             case LRPC_NONCE:
                 n = "Nonce"; break;
             default:
-                sprintf(tmp, "Type=0x%x", (unsigned short)typ);
+                snprintf(tmp, sizeof(tmp), "Type=0x%x", (unsigned short)typ);
                 n = tmp;
                 break;
             }

--- a/src/ccnl-utils/src/ccn-lite-produce.c
+++ b/src/ccnl-utils/src/ccn-lite-produce.c
@@ -234,7 +234,7 @@ Usage:
             is_last = 1;
         }
 
-        strcpy(url, url_orig);
+        strncpy(url, url_orig, strlen(url_orig));
         offs = CCNL_MAX_PACKET_SIZE;
         name = ccnl_URItoPrefix(url, suite, &chunknum);
 

--- a/src/ccnl-utils/src/ccn-lite-produce.c
+++ b/src/ccnl-utils/src/ccn-lite-produce.c
@@ -262,7 +262,7 @@ Usage:
         }
 
         if (outdirname) {
-            sprintf(outpathname, "%s/%s%d.%s", outdirname, outfname, chunknum, fileext);
+            snprintf(outpathname, sizeof(outpathname), "%s/%s%d.%s", outdirname, outfname, chunknum, fileext);
 
             DEBUGMSG(INFO, "writing chunk %d to file %s\n", chunknum, outpathname);
 

--- a/src/ccnl-utils/src/ccn-lite-rpc.c
+++ b/src/ccnl-utils/src/ccn-lite-rpc.c
@@ -223,7 +223,7 @@ int ccnl_rdr_dump(int lev, struct rdr_ds_s *x)
     if (t < LRPC_NOT_SERIALIZED)
         return t;
     if (t < LRPC_APPLICATION) {
-        sprintf(tmp, "v%02x", t);
+        snprintf(tmp, sizeof(tmp), "v%02x", t);
         n = tmp;
     } else switch (t) {
     case LRPC_APPLICATION:

--- a/src/ccnl-utils/src/ccn-lite-rpc.c
+++ b/src/ccnl-utils/src/ccn-lite-rpc.c
@@ -415,7 +415,7 @@ Usage:
     if (ux) { // use UNIX socket
         struct sockaddr_un *su = (struct sockaddr_un*) &sa;
         su->sun_family = AF_UNIX;
-        strcpy(su->sun_path, ux);
+        strncpy(su->sun_path, ux, sizeof(su->sun_path));
         sock = ux_open();
     } else { // UDP
         struct sockaddr_in *si = (struct sockaddr_in*) &sa;

--- a/src/ccnl-utils/src/ccnl-socket.c
+++ b/src/ccnl-utils/src/ccnl-socket.c
@@ -94,7 +94,7 @@ ux_open()
     int sock, bufsize;
     struct sockaddr_un name;
 
-    sprintf(mysockname, "/tmp/.ccn-lite-peek-%d.sock", getpid());
+    snprintf(mysockname, sizeof(mysockname), "/tmp/.ccn-lite-peek-%d.sock", getpid());
     unlink(mysockname);
 
     sock = socket(AF_UNIX, SOCK_DGRAM, 0);

--- a/src/ccnl-utils/src/ccnl-socket.c
+++ b/src/ccnl-utils/src/ccnl-socket.c
@@ -76,7 +76,7 @@ udp_sendto(int sock, char *dest, unsigned char *data, int len)
 {
     struct sockaddr_in dst;
     char buf[256];
-    strcpy(buf, dest);
+    strncpy(buf, dest, sizeof(buf));
 
     dst.sin_family = PF_INET;
     dst.sin_addr.s_addr = inet_addr(strtok(buf, "/"));
@@ -103,7 +103,7 @@ ux_open()
         exit(1);
     }
     name.sun_family = AF_UNIX;
-    strcpy(name.sun_path, mysockname);
+    strncpy(name.sun_path, mysockname, sizeof(name.sun_path));
     if (bind(sock, (struct sockaddr *) &name,
              sizeof(struct sockaddr_un))) {
         perror("binding path name to datagram socket");
@@ -124,7 +124,7 @@ ux_sendto(int sock, char *topath, uint8_t *data, size_t len)
     struct sockaddr_un name;
 
     name.sun_family = AF_UNIX;
-    strcpy(name.sun_path, topath);
+    strncpy(name.sun_path, topath, sizeof(name.sun_path));
 
     return sendto(sock, data, len, 0, (struct sockaddr*) &name,
                   sizeof(struct sockaddr_un));


### PR DESCRIPTION
## Contribution description

Replace `sprintf()` with `snprintf()`, `strcpy()` with `strncpy()`, and `strcat()` with `strncat()` wherever feasible.

Some of these changes might be a little overzealous. Not all uses of the unsafe functions are necessarily unsafe. Feel free to cherrypick/ignore as needed.

### Issues/PRs references

Changes follow the same style as #337.
