### PR TITLE
Fix for ccn-lite Kernel version to run on Linux Kernels > 4.15

### DIFF
--- a/src/ccnl-core/include/ccnl-content.h
+++ b/src/ccnl-core/include/ccnl-content.h
@@ -24,7 +24,11 @@
 #define CCNL_CONTENT_H
 
 #include <stdbool.h>
+#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
+#endif
 
 #ifdef CCNL_RIOT
 #include "evtimer_msg.h"

--- a/src/ccnl-core/include/ccnl-content.h
+++ b/src/ccnl-core/include/ccnl-content.h
@@ -24,11 +24,7 @@
 #define CCNL_CONTENT_H
 
 #include <stdbool.h>
-#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
-#else
-#include <linux/types.h>
-#endif
 
 #ifdef CCNL_RIOT
 #include "evtimer_msg.h"

--- a/src/ccnl-core/include/ccnl-content.h
+++ b/src/ccnl-core/include/ccnl-content.h
@@ -24,7 +24,12 @@
 #define CCNL_CONTENT_H
 
 #include <stdbool.h>
+#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
+
+#endif
 
 #ifdef CCNL_RIOT
 #include "evtimer_msg.h"

--- a/src/ccnl-core/include/ccnl-malloc.h
+++ b/src/ccnl-core/include/ccnl-malloc.h
@@ -108,6 +108,7 @@ debug_strdup(const char *s, const char *fn, int lno, char *tstamp);
  * @return Upon failure, the function returns NULL
  * @return Upon success, a pointer to the memory block allocated by the function
  */
+/*
 static inline void*
 ccnl_malloc(size_t s);
 
@@ -115,7 +116,7 @@ static inline void*
 ccnl_calloc(size_t num, size_t size);
 
 static inline void
-ccnl_free(void *ptr);
+ccnl_free(void *ptr);*/
 #endif
 
 #endif 

--- a/src/ccnl-core/include/ccnl-mgmt.h
+++ b/src/ccnl-core/include/ccnl-mgmt.h
@@ -23,7 +23,11 @@
 
 #ifdef USE_MGMT
 
+#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
+#endif
 
 struct ccnl_buf_s;
 struct ccnl_relay_s;

--- a/src/ccnl-core/include/ccnl-mgmt.h
+++ b/src/ccnl-core/include/ccnl-mgmt.h
@@ -23,11 +23,7 @@
 
 #ifdef USE_MGMT
 
-#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
-#else
-#include <linux/types.h>
-#endif
 
 struct ccnl_buf_s;
 struct ccnl_relay_s;

--- a/src/ccnl-core/include/ccnl-os-time.h
+++ b/src/ccnl-core/include/ccnl-os-time.h
@@ -25,8 +25,6 @@
 
 #ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
-#else
-#include <linux/types.h>
 #endif
 
  #ifdef CCNL_ARDUINO

--- a/src/ccnl-core/include/ccnl-os-time.h
+++ b/src/ccnl-core/include/ccnl-os-time.h
@@ -25,6 +25,8 @@
 
 #ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
 #endif
 
  #ifdef CCNL_ARDUINO

--- a/src/ccnl-core/include/ccnl-pkt-util.h
+++ b/src/ccnl-core/include/ccnl-pkt-util.h
@@ -22,7 +22,11 @@
 #ifndef CCNL_PKT_UTIL_H
 #define CCNL_PKT_UTIL_H
 
+#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
+#endif
 #include <stddef.h>
 
 #include "ccnl-pkt.h"

--- a/src/ccnl-core/include/ccnl-pkt-util.h
+++ b/src/ccnl-core/include/ccnl-pkt-util.h
@@ -22,11 +22,7 @@
 #ifndef CCNL_PKT_UTIL_H
 #define CCNL_PKT_UTIL_H
 
-#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
-#else
-#include <linux/types.h>
-#endif
 #include <stddef.h>
 
 #include "ccnl-pkt.h"

--- a/src/ccnl-core/include/ccnl-pkt.h
+++ b/src/ccnl-core/include/ccnl-pkt.h
@@ -25,13 +25,21 @@
 #define CCNL_PKT_H
 
 #include <stddef.h>
+#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
+#endif
 
 #include "ccnl-buf.h"
 #include "ccnl-prefix.h"
 
 #ifdef USE_SUITE_NDNTLV
+#ifndef CCNL_LINUXKERNEL
 #include "ccnl-pkt-ndntlv.h"
+#else
+#include "../../ccnl-pkt/include/ccnl-pkt-ndntlv.h"
+#endif
 #endif
 
 // packet flags:  0000ebtt

--- a/src/ccnl-core/include/ccnl-prefix.h
+++ b/src/ccnl-core/include/ccnl-prefix.h
@@ -25,7 +25,11 @@
 #define CCNL_PREFIX_H
 
 #include <stddef.h>
+#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
+#endif
 #ifndef CCNL_LINUXKERNEL
 #include <unistd.h>
 #endif
@@ -208,6 +212,7 @@ ccnl_prefix_to_str_detailed(struct ccnl_prefix_s *pr, int ccntlv_skip, int escap
  *
  * @return the created URI
 */
+    char* ccnl_prefix_to_str(struct ccnl_prefix_s *pr, char* buf,size_t buflen);
    char* ccnl_prefix_to_path(struct ccnl_prefix_s *pr);
 #endif
 

--- a/src/ccnl-core/include/ccnl-prefix.h
+++ b/src/ccnl-core/include/ccnl-prefix.h
@@ -25,11 +25,7 @@
 #define CCNL_PREFIX_H
 
 #include <stddef.h>
-#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
-#else
-#include <linux/types.h>
-#endif
 #ifndef CCNL_LINUXKERNEL
 #include <unistd.h>
 #endif

--- a/src/ccnl-core/include/ccnl-prefix.h
+++ b/src/ccnl-core/include/ccnl-prefix.h
@@ -25,7 +25,11 @@
 #define CCNL_PREFIX_H
 
 #include <stddef.h>
+#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
+#endif
 #ifndef CCNL_LINUXKERNEL
 #include <unistd.h>
 #endif

--- a/src/ccnl-core/src/ccnl-buf.c
+++ b/src/ccnl-core/src/ccnl-buf.c
@@ -30,13 +30,13 @@
 #include "ccnl-prefix.h"
 #include "ccnl-malloc.h"
 #else
-#include <ccnl-os-time.h>
-#include <ccnl-buf.h>
-#include <ccnl-logging.h>
-#include <ccnl-relay.h>
-#include <ccnl-forward.h>
-#include <ccnl-prefix.h>
-#include <ccnl-malloc.h>
+#include "../include/ccnl-os-time.h"
+#include "../include/ccnl-buf.h"
+#include "../include/ccnl-logging.h"
+#include "../include/ccnl-relay.h"
+#include "../include/ccnl-forward.h"
+#include "../include/ccnl-prefix.h"
+#include "../include/ccnl-malloc.h"
 #endif
 
 struct ccnl_buf_s*

--- a/src/ccnl-core/src/ccnl-content.c
+++ b/src/ccnl-core/src/ccnl-content.c
@@ -29,12 +29,12 @@
 #include "ccnl-logging.h"
 #include "ccnl-defs.h"
 #else
-#include <ccnl-content.h>
-#include <ccnl-malloc.h>
-#include <ccnl-prefix.h>
-#include <ccnl-pkt.h>
-#include <ccnl-os-time.h>
-#include <ccnl-logging.h>
+#include "../include/ccnl-content.h"
+#include "../include/ccnl-malloc.h"
+#include "../include/ccnl-prefix.h"
+#include "../include/ccnl-pkt.h"
+#include "../include/ccnl-os-time.h"
+#include "../include/ccnl-logging.h"
 #endif
 
 // TODO: remove unused ccnl parameter

--- a/src/ccnl-core/src/ccnl-if.c
+++ b/src/ccnl-core/src/ccnl-if.c
@@ -34,10 +34,10 @@
 #endif
 #include <unistd.h>
 #else
-#include <ccnl-if.h>
-#include <ccnl-os-time.h>
-#include <ccnl-malloc.h>
-#include <ccnl-logging.h>
+#include "../include/ccnl-if.h"
+#include "../include/ccnl-os-time.h"
+#include "../include/ccnl-malloc.h"
+#include "../include/ccnl-logging.h"
 #endif
 
 void

--- a/src/ccnl-core/src/ccnl-interest.c
+++ b/src/ccnl-core/src/ccnl-interest.c
@@ -30,13 +30,13 @@
 #include "ccnl-logging.h"
 #include "ccnl-pkt-util.h"
 #else
-#include <ccnl-relay.h>
-#include <ccnl-interest.h>
-#include <ccnl-malloc.h>
-#include <ccnl-os-time.h>
-#include <ccnl-prefix.h>
-#include <ccnl-logging.h>
-#include <ccnl-pkt-util.h>
+#include "../include/ccnl-relay.h"
+#include "../include/ccnl-interest.h"
+#include "../include/ccnl-malloc.h"
+#include "../include/ccnl-os-time.h"
+#include "../include/ccnl-prefix.h"
+#include "../include/ccnl-logging.h"
+#include "../include/ccnl-pkt-util.h"
 #endif
 
 #ifdef CCNL_RIOT

--- a/src/ccnl-core/src/ccnl-logging.c
+++ b/src/ccnl-core/src/ccnl-logging.c
@@ -25,7 +25,7 @@
 #include <string.h>
 #include <stdio.h>
 #else
-#include <ccnl-logging.h>
+#include "../include/ccnl-logging.h"
 #endif
 
 int debug_level;

--- a/src/ccnl-core/src/ccnl-mgmt.c
+++ b/src/ccnl-core/src/ccnl-mgmt.c
@@ -33,14 +33,14 @@
 #include <errno.h>
 #include <limits.h>
 #else
-#include <ccnl-mgmt.h>
-#include <ccnl-core.h>
-#include <ccnl-pkt-ccnb.h>
-#include <ccnl-pkt-builder.h>
-#include <ccnl-dump.h>
-#include <ccnl-crypto.h>
-#include <ccnl-forward.h>
-#include <ccnl-pkt-switch.h>
+#include "../include/ccnl-mgmt.h"
+#include "../include/ccnl-core.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-ccnb.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-builder.h"
+#include "../include/ccnl-dump.h"
+#include "../include/ccnl-crypto.h"
+#include "../include/ccnl-forward.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-switch.h"
 #endif
 
 

--- a/src/ccnl-core/src/ccnl-pkt-util.c
+++ b/src/ccnl-core/src/ccnl-pkt-util.c
@@ -18,7 +18,7 @@
  * File history:
  * 2017-06-20 created
  */
-
+#ifndef CCNL_LINUXKERNEL
 #include "ccnl-pkt-util.h"
 #include "ccnl-defs.h"
 #include "ccnl-os-time.h"
@@ -27,6 +27,16 @@
 #include "ccnl-pkt-ndntlv.h"
 #include "ccnl-pkt-switch.h"
 #include "ccnl-logging.h"
+#else
+#include "../include/ccnl-pkt-util.h"
+#include "../include/ccnl-defs.h"
+#include "../include/ccnl-os-time.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-ccnb.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-ccntlv.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-ndntlv.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-switch.h"
+#include "../include/ccnl-logging.h"
+#endif
 
 int
 ccnl_str2suite(char *cp)

--- a/src/ccnl-core/src/ccnl-pkt.c
+++ b/src/ccnl-core/src/ccnl-pkt.c
@@ -19,7 +19,7 @@
  * File history:
  * 2017-06-16 created
  */
-
+#ifndef CCNL_LINUXKERNEL
 #include "ccnl-pkt.h"
 
 #include "ccnl-os-time.h"
@@ -30,6 +30,18 @@
 #include "ccnl-malloc.h"
 
 #include "ccnl-logging.h"
+#else
+#include "../include/ccnl-pkt.h"
+
+#include "../include/ccnl-os-time.h"
+#include "../include/ccnl-defs.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-ccntlv.h"
+
+#include "../include/ccnl-prefix.h"
+#include "../include/ccnl-malloc.h"
+
+#include "../include/ccnl-logging.h"
+#endif
 
 void
 ccnl_pkt_free(struct ccnl_pkt_s *pkt)

--- a/src/ccnl-core/src/ccnl-relay.c
+++ b/src/ccnl-core/src/ccnl-relay.c
@@ -26,7 +26,7 @@
 #include <inttypes.h>
 #include <assert.h>
 #else //CCNL_LINUXKERNEL
-#include <ccnl-core.h>
+#include "../include/ccnl-core.h"
 #endif //CCNL_LINUXKERNEL
 
 #ifdef CCNL_RIOT

--- a/src/ccnl-core/src/ccnl-sched.c
+++ b/src/ccnl-core/src/ccnl-sched.c
@@ -27,10 +27,10 @@
 #include "ccnl-logging.h"
 #include <string.h>
 #else
-#include <ccnl-sched.h>
-#include <ccnl-malloc.h>
-#include <ccnl-os-time.h>
-#include <ccnl-logging.h>
+#include "../include/ccnl-sched.h"
+#include "../include/ccnl-malloc.h"
+#include "../include/ccnl-os-time.h"
+#include "../include/ccnl-logging.h"
 #endif
 
 

--- a/src/ccnl-core/src/ccnl-sockunion.c
+++ b/src/ccnl-core/src/ccnl-sockunion.c
@@ -27,8 +27,8 @@
 #include <string.h>
 #include "ccnl-logging.h"
 #else
-#include <ccnl-logging.h>
-#include <ccnl-sockunion.h>
+#include "../include/ccnl-logging.h"
+#include "../include/ccnl-sockunion.h"
 #endif
 
 int

--- a/src/ccnl-fwd/include/ccnl-fwd.h
+++ b/src/ccnl-fwd/include/ccnl-fwd.h
@@ -24,7 +24,11 @@
 #ifndef CCNL_FWD_H
 #define CCNL_FWD_H
 
+#ifndef CCNL_LINUXKERNEL
 #include "ccnl-core.h"
+#else
+#include "../../ccnl-core/include/ccnl-core.h"
+#endif
 
 /**
  * @brief       Functionpointer to a CCN-lite Forwarder Function

--- a/src/ccnl-fwd/include/ccnl-localrpc.h
+++ b/src/ccnl-fwd/include/ccnl-localrpc.h
@@ -22,8 +22,14 @@
 #ifndef CCNL_LOCALRPC_H
 #define CCNL_LOCALRPC_H
 
+#ifndef CCNL_LINUXKERNEL
 #include "ccnl-relay.h"
 #include "ccnl-face.h"
+#else
+#include "../../ccnl-core/include/ccnl-relay.h"
+#include "../../ccnl-core/include/ccnl-face.h"
+#endif
+
 
 
 /**

--- a/src/ccnl-fwd/src/ccnl-dispatch.c
+++ b/src/ccnl-fwd/src/ccnl-dispatch.c
@@ -18,7 +18,7 @@
  * File history:
  * 2017-06-20 created
  */
-
+#ifndef CCNL_LINUXKERNEL
 #include "ccnl-dispatch.h"
 
 #include "ccnl-os-time.h"
@@ -37,6 +37,27 @@
 #include "ccnl-pkt-localrpc.h"
 
 #include "ccnl-logging.h"
+#else
+#include "../include/ccnl-dispatch.h"
+
+#include "../../ccnl-core/include/ccnl-os-time.h"
+
+#include "../include/ccnl-localrpc.h"
+
+#include "../../ccnl-core/include/ccnl-relay.h"
+#include "../../ccnl-core/include/ccnl-pkt-util.h"
+
+#include "../include/ccnl-fwd.h"
+
+#include "../../ccnl-pkt/include/ccnl-pkt-ccnb.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-ccntlv.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-ndntlv.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-switch.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-localrpc.h"
+
+#include "../../ccnl-core/include/ccnl-logging.h"
+#endif
+
 
 struct ccnl_suite_s ccnl_core_suites[CCNL_SUITE_LAST];
 

--- a/src/ccnl-fwd/src/ccnl-fwd.c
+++ b/src/ccnl-fwd/src/ccnl-fwd.c
@@ -19,28 +19,29 @@
  * File history:
  * 2017-06-16 created
  */
-
-
+#ifndef CCNL_LINUXKERNEL
+#include <inttypes.h>
+#include <limits.h>
 #include "ccnl-fwd.h"
-
 #include "ccnl-core.h"
 #include "ccnl-producer.h"
 #include "ccnl-callbacks.h"
-
 #include "ccnl-pkt-util.h"
-
-#ifndef CCNL_LINUXKERNEL
 #include "ccnl-pkt-ccnb.h"
 #include "ccnl-pkt-ccntlv.h"
 #include "ccnl-pkt-ndntlv.h"
 #include "ccnl-pkt-switch.h"
-#include <inttypes.h>
-#include <limits.h>
 #else
-#include <ccnl-pkt-ccnb.h>
-#include <ccnl-pkt-ccntlv.h>
-#include <ccnl-pkt-ndntlv.h>
-#include <ccnl-pkt-switch.h>
+#include <linux/types.h>
+#include "../include/ccnl-fwd.h"
+#include "../../ccnl-core/include/ccnl-core.h"
+#include "../../ccnl-core/include/ccnl-producer.h"
+#include "../../ccnl-core/include/ccnl-callbacks.h"
+#include "../../ccnl-core/include/ccnl-pkt-util.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-ccnb.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-ccntlv.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-ndntlv.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-switch.h"
 #endif
 
 //#include "ccnl-logging.h"
@@ -83,11 +84,12 @@ ccnl_fwd_handleContent(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
             return ccnl_crypto(relay, pkt->buf, pkt->pfx, from);
         }
 #endif /* USE_SUITE_CCNB && USE_SIGNATURES*/
-
+#ifndef CCNL_LINUXKERNEL
     if (ccnl_callback_rx_on_data(relay, from, *pkt)) {
         *pkt = NULL;
         return 0;
     }
+#endif
 
     // CONFORM: Step 1:
     for (c = relay->contents; c; c = c->next) {
@@ -219,9 +221,11 @@ ccnl_fwd_handleInterest(struct ccnl_relay_s *relay, struct ccnl_face_s *from,
         return 0;
     }
 #endif
+#ifndef CCNL_LINUXKERNEL
     if (local_producer(relay, from, *pkt)) {
         return 0;
     }
+#endif
 #if defined(USE_SUITE_CCNB) && defined(USE_MGMT)
     if ((*pkt)->suite == CCNL_SUITE_CCNB && (*pkt)->pfx->compcnt == 4 &&
                                   !memcmp((*pkt)->pfx->comp[0], "ccnx", 4)) {

--- a/src/ccnl-lnxkernel/ccn-lite-lnxkernel.c
+++ b/src/ccnl-lnxkernel/ccn-lite-lnxkernel.c
@@ -77,16 +77,35 @@
 
 #define USE_LINKLAYER
 
-#include <ccnl-defs.h>
-#include <ccnl-frag.h>
-#include <ccnl-mgmt.h>
-#include <ccnl-crypto.h>
-#include <ccnl-os-time.h>
-#include <ccnl-logging.h>
-#include <ccnl-dispatch.h>
-#include <ccnl-malloc.h>
-#include <ccnl-producer.h>
-#include <ccnl-pkt-switch.h>
+
+#include "../../ccnl-core/include/ccnl-defs.h"
+#include "../../ccnl-core/include/ccnl-frag.h"
+#include "../../ccnl-core/include/ccnl-mgmt.h"
+#include "../../ccnl-core/include/ccnl-crypto.h"
+#include "../../ccnl-core/include/ccnl-os-time.h"
+#include "../../ccnl-core/include/ccnl-logging.h"
+#include "../../ccnl-fwd/include/ccnl-dispatch.h"
+#include "../../ccnl-core/include/ccnl-malloc.h"
+#include "../../ccnl-core/include/ccnl-producer.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-switch.h"
+
+static inline void*
+ccnl_malloc(int s)
+{
+return kmalloc(s, GFP_ATOMIC);
+}
+
+static inline void*
+ccnl_calloc(int n, int s)
+{
+return kcalloc(n, s, GFP_ATOMIC);
+}
+
+static inline void
+ccnl_free(void *ptr)
+{
+kfree(ptr);
+}
 
 #include "../../ccnl-pkt/src/ccnl-pkt-switch.c"
 #ifdef USE_SUITE_NDNTLV
@@ -158,23 +177,7 @@ inet_ntoa(struct in_addr in)
 #endif
 // ----------------------------------------------------------------------
 
-static inline void*
-ccnl_malloc(int s)
-{
-    return kmalloc(s, GFP_ATOMIC);
-}
 
-static inline void*
-ccnl_calloc(int n, int s)
-{
-    return kcalloc(n, s, GFP_ATOMIC);
-}
-
-static inline void
-ccnl_free(void *ptr)
-{
-    kfree(ptr);
-}
 
 static void ccnl_lnxkernel_cleanup(void);
 char* ccnl_addr2ascii(sockunion *su);

--- a/src/ccnl-pkt/include/ccnl-pkt-builder.h
+++ b/src/ccnl-pkt/include/ccnl-pkt-builder.h
@@ -20,6 +20,7 @@
 #ifndef CCNL_PKT_BUILDER
 #define CCNL_PKT_BUILDER
 
+#ifndef CCNL_LINUXKERNEL
 #include "ccnl-core.h"
 
 #include "ccnl-pkt.h"
@@ -28,6 +29,17 @@
 #include "ccnl-pkt-ndntlv.h"
 #include "ccnl-pkt-switch.h"
 #include "ccnl-pkt-localrpc.h"
+#else
+#include "../../ccnl-core/include/ccnl-core.h"
+
+#include "../../ccnl-core/include/ccnl-pkt.h"
+#include "../include/ccnl-pkt-ccnb.h"
+#include "../include/ccnl-pkt-ccntlv.h"
+#include "../include/ccnl-pkt-ndntlv.h"
+#include "../include/ccnl-pkt-switch.h"
+#include "../include/ccnl-pkt-localrpc.h"
+#endif
+
 
 #ifdef USE_SUITE_CCNB
 int8_t ccnb_isContent(uint8_t *buf, size_t len);

--- a/src/ccnl-pkt/include/ccnl-pkt-ccnb.h
+++ b/src/ccnl-pkt/include/ccnl-pkt-ccnb.h
@@ -24,7 +24,11 @@
 #ifndef CCNL_PKT_CCNB_H
 #define CCNL_PKT_CCNB_H
 
+#ifndef CCNL_LINUXKERNEL
 #include "ccnl-core.h"
+#else
+#include "../../ccnl-core/include/ccnl-core.h"
+#endif
 
 // ----------------------------------------------------------------------
 

--- a/src/ccnl-pkt/include/ccnl-pkt-ccntlv.h
+++ b/src/ccnl-pkt/include/ccnl-pkt-ccntlv.h
@@ -23,11 +23,17 @@
 #ifndef CCNL_PKT_CCNTLV_H
 #define CCNL_PKT_CCNTLV_H
 
-#ifndef  CCNL_LINUXKERNEL
+#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
 #endif
 
+#ifndef CCNL_LINUXKERNEL
 #include "ccnl-core.h"
+#else
+#include "../../ccnl-core/include/ccnl-core.h"
+#endif
 
 #ifndef CCN_UDP_PORT
 # define CCN_UDP_PORT                    9695

--- a/src/ccnl-pkt/include/ccnl-pkt-localrpc.h
+++ b/src/ccnl-pkt/include/ccnl-pkt-localrpc.h
@@ -23,8 +23,13 @@
 #ifndef CCNL_PKT_LOCALRPC_H
 #define CCNL_PKT_LOCALRPC_H
 
-#include "ccnl-face.h"
+#ifndef CCNL_LINUXKERNEL
 #include "ccnl-relay.h"
+#include "ccnl-face.h"
+#else
+#include "../../ccnl-core/include/ccnl-relay.h"
+#include "../../ccnl-core/include/ccnl-face.h"
+#endif
 
 struct rpc_exec_s { // execution context
     struct rdr_ds_s *ostack; // operands

--- a/src/ccnl-pkt/include/ccnl-pkt-ndntlv.h
+++ b/src/ccnl-pkt/include/ccnl-pkt-ndntlv.h
@@ -23,10 +23,19 @@
 #ifndef CCNL_PKT_NDNTLV_H
 #define CCNL_PKT_NDNTLV_H
 
+#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
+# define UINT8_MAX		(255)
+#endif
 #include <stddef.h>
-
+#ifndef CCNL_LINUXKERNEL
 #include "ccnl-content.h"
+#else
+#include "../../ccnl-core/include/ccnl-content.h"
+#endif
+
 
 /**
  * Default interest lifetime in milliseconds. If the element is omitted by a user, a default

--- a/src/ccnl-pkt/include/ccnl-pkt-switch.h
+++ b/src/ccnl-pkt/include/ccnl-pkt-switch.h
@@ -23,7 +23,11 @@
 #ifndef CCNL_PKT_SWITCH_H
 #define CCNL_PKT_SWITCH_H
 
+#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
+#endif
 #include <stddef.h>
 
 int8_t
@@ -33,9 +37,10 @@ int
 ccnl_enc2suite(int enc);
 
 #ifdef NEEDS_PACKET_CRAFTING
+#ifndef CCNL_LINUXKERNEL
 int
 ccnl_switch_prependCodeVal(unsigned long val, int *offset, unsigned char *buf);
-
+#endif
 int8_t
 ccnl_switch_prependCoding(uint64_t code, size_t *offset, uint8_t *buf, size_t *res);
 

--- a/src/ccnl-pkt/src/ccnl-pkt-ccnb.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ccnb.c
@@ -37,8 +37,8 @@
 #include <ctype.h>
 #include <assert.h>
 #else
-#include <ccnl-pkt-ccnb.h>
-#include <ccnl-core.h>
+#include "../include/ccnl-pkt-ccnb.h"
+#include "../../ccnl-core/include/ccnl-core.h"
 #endif
 
 

--- a/src/ccnl-pkt/src/ccnl-pkt-ccntlv.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ccntlv.c
@@ -32,8 +32,8 @@
 #include <arpa/inet.h>
 #include <assert.h>
 #else
-#include <ccnl-pkt-ccntlv.h>
-#include <ccnl-core.h>
+#include "../include/ccnl-pkt-ccntlv.h"
+#include "../../ccnl-core/include/ccnl-core.h"
 #endif
 
 

--- a/src/ccnl-pkt/src/ccnl-pkt-localrpc.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-localrpc.c
@@ -32,9 +32,9 @@
 #include <ccnl-pkt-localrpc.h>
 
 #else
-#include <ccnl-pkt-localrpc.h>
-#include <ccnl-core.h>
-#include <ccnl-pkt-ndntlv.h>
+#include "../include/ccnl-pkt-localrpc.h"
+#include "../../ccnl-core/include/ccnl-core.h"
+#include "../../ccnl-pkt/include/ccnl-pkt-ndntlv.h"
 #endif
 
 // ----------------------------------------------------------------------

--- a/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-ndntlv.c
@@ -32,8 +32,11 @@
 #include <assert.h>
 #include <stdint.h>
 #else
-#include <ccnl-pkt-ndntlv.h>
-#include <ccnl-core.h>
+#include <linux/types.h>
+#include "../include/ccnl-pkt-ndntlv.h"
+#include "../../ccnl-core/include/ccnl-core.h"
+# define UINT32_MAX		(4294967295U)
+# define UINT16_MAX		(65535)
 #endif
 
 

--- a/src/ccnl-pkt/src/ccnl-pkt-switch.c
+++ b/src/ccnl-pkt/src/ccnl-pkt-switch.c
@@ -22,11 +22,19 @@
 
 // see ccnl-defs.h for the ENC constants
 
+#ifndef CCNL_LINUXKERNEL
 #include "ccnl-core.h"
-
 #include "ccnl-pkt-ccnb.h"
 #include "ccnl-pkt-ccntlv.h"
 #include "ccnl-pkt-ndntlv.h"
+#else
+#include "../../ccnl-core/include/ccnl-core.h"
+#include "../include/ccnl-pkt-ccnb.h"
+#include "../include/ccnl-pkt-ccntlv.h"
+#include "../include/ccnl-pkt-ndntlv.h"
+#endif
+
+
 
 int8_t
 ccnl_switch_dehead(uint8_t **buf, size_t *len, int32_t *code)

--- a/src/ccnl-utils/include/base64.h
+++ b/src/ccnl-utils/include/base64.h
@@ -7,7 +7,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
+#endif
 
 /**
  * @brief Initializes the base64 decoding table

--- a/src/ccnl-utils/include/lib-sha256.h
+++ b/src/ccnl-utils/include/lib-sha256.h
@@ -4,7 +4,11 @@
  *
  */
 #include <assert.h>
+#ifndef CCNL_LINUXKERNEL
 #include <stdint.h>
+#else
+#include <linux/types.h>
+#endif
 #include <string.h>
 
 #ifdef CCNL_ARDUINO


### PR DESCRIPTION
### Contribution description

- Fixes all includes that were not working anymore when compiling for the Linux kernel since the restructuring of the ccn-lite project. Involved are all Files concerning the Linux Kernel Version.
- With Linux Kernel headers > 4.15 the kernel timer changed, this uses the new way to do it. Solution adapted from here: https://gist.github.com/fcomida/081891670a11f90a5e44b166ec7479cb. Involved is ccnl-os-time.h and ccnl-os-time-c
- Moves the definition of ccnl_malloc, ccnl_calloc and ccnl_free for the kernel version before on top of the includes of source files since the definitions are needed in them. Removes a superfluous definition of these functions from ccnl-malloc.h. Affected are ccnl-malloc.h and ccn-lite-lnxkernel.c
- ccn-lite Linux Kernel Version now runs on Ubuntu 18.04 with kernel version 5.4



### Issues/PRs references


Fixes #300

