### PR TITLE
adapt to API changes in RIOT

### DIFF
--- a/src/ccnl-core/include/ccnl-defs.h
+++ b/src/ccnl-core/include/ccnl-defs.h
@@ -37,12 +37,7 @@
 #define CCNL_BROADCAST_OCTET            0xFF
 
 #if defined(CCNL_ARDUINO) || defined(CCNL_RIOT)
-# if defined(CCNL_RIOT)
-#  include "net/gnrc/netif.h"
-#  define CCNL_MAX_INTERFACES            GNRC_NETIF_NUMOF
-# else
-#  define CCNL_MAX_INTERFACES            1
-# endif
+# define CCNL_MAX_INTERFACES             1
 # define CCNL_MAX_IF_QLEN                14
 #ifndef CCNL_MAX_PACKET_SIZE
 # define CCNL_MAX_PACKET_SIZE            120

--- a/src/ccnl-core/include/ccnl-if.h
+++ b/src/ccnl-core/include/ccnl-if.h
@@ -24,7 +24,7 @@
 #define CCNL_IF_H
 
 #if defined(CCNL_RIOT)
-#include "kernel_types.h"
+#include "sched.h"
 #endif
 
 #include "ccnl-sched.h"

--- a/src/ccnl-riot/include/ccn-lite-riot.h
+++ b/src/ccnl-riot/include/ccn-lite-riot.h
@@ -21,7 +21,7 @@
  */
 
 #include <unistd.h>
-#include "kernel_types.h"
+#include "sched.h"
 #include "arpa/inet.h"
 #include "net/packet.h"
 #include "net/ethernet/hdr.h"

--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -29,7 +29,7 @@
 #include <time.h>
 
 /* RIOT specific includes */
-#include "kernel_types.h"
+#include "sched.h"
 #include "random.h"
 #include "timex.h"
 #include "xtimer.h"


### PR DESCRIPTION
<!--
Before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the CCN-lite
coding conventions, see https://github.com/cn-uofbasel/ccn-lite/wiki/Coding-conventions.
-->

### Contribution description

There have been two changes to the RIOT API

 - `GNRC_NETIF_NUMOF` got removed. Network interfaces are now allocated dynamically at run time, there is no more compile-time fixed number
 - `kernel_types.h` was removed. Scheduler defines now live in `sched.h`.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
