### PR TITLE
RIOT support: Added cast to debug message

### DIFF
--- a/src/ccnl-riot/src/ccn-lite-riot.c
+++ b/src/ccnl-riot/src/ccn-lite-riot.c
@@ -278,7 +278,7 @@ int
 ccnl_app_RX(struct ccnl_relay_s *ccnl, struct ccnl_content_s *c)
 {
     (void) ccnl;
-    DEBUGMSG(DEBUG, "Received something of size %u for the application\n", c->pkt->contlen);
+    DEBUGMSG(DEBUG, "Received something of size %u for the application\n", (unsigned)c->pkt->contlen);
 
     gnrc_pktsnip_t *pkt= gnrc_pktbuf_add(NULL, c->pkt->content,
                                          c->pkt->contlen,


### PR DESCRIPTION
### Contribution description

Minor change to fix compiler warning.

`contlen` is of type `size_t`. Depending on the platform, this may have a different size than `unsigned int`. According to the RIOT encoding conventions, `size_t` variables should be converted to `unsigned` in printouts if possible, since `%zu' is not supported by `newlib-nano`.
